### PR TITLE
[HOTFIX] ErrorResponse에서 status 제거

### DIFF
--- a/src/main/java/com/dekk/common/error/ErrorResponse.java
+++ b/src/main/java/com/dekk/common/error/ErrorResponse.java
@@ -3,11 +3,9 @@ package com.dekk.common.error;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import java.util.List;
-import org.springframework.http.HttpStatus;
 
 @JsonInclude(Include.NON_NULL)
 public record ErrorResponse(
-    HttpStatus status,
     String code,
     String message,
     List<String> errors
@@ -18,7 +16,6 @@ public record ErrorResponse(
 
     public static ErrorResponse of(ErrorCode errorCode, List<String> errors) {
         return new ErrorResponse(
-            errorCode.status(),
             errorCode.code(),
             errorCode.message(),
             errors


### PR DESCRIPTION
## #️⃣연관된 이슈

[지라 태스크 링크](https://potenup-final.atlassian.net/browse/DK-35?atlOrigin=eyJpIjoiODYwZDA5ZmJlNTFlNDg5NzgzMDVjOWU1OWYxZDgyNDgiLCJwIjoiaiJ9)

## 📝작업 내용
- ErrorResponse에서 HttpStatus 제거
- ResponseEntity에서 HttpStatus를 정의하므로 불필요한 값입니다!
