### PR TITLE
[REFACTOR] 카드 키, 몸무게 타입 수정

### DIFF
--- a/src/main/java/com/dekk/card/application/command/CardCreateCommand.java
+++ b/src/main/java/com/dekk/card/application/command/CardCreateCommand.java
@@ -11,7 +11,7 @@ public record CardCreateCommand(
     String originId,
     boolean isActive,
     Platform platform,
-    Double height,
-    Double weight
+    Integer height,
+    Integer weight
 ) {
 }

--- a/src/main/java/com/dekk/card/domain/model/Card.java
+++ b/src/main/java/com/dekk/card/domain/model/Card.java
@@ -5,9 +5,7 @@ import com.dekk.card.domain.exception.CardBusinessException;
 import com.dekk.card.domain.exception.CardErrorCode;
 import com.dekk.card.domain.model.enums.Platform;
 import jakarta.persistence.CascadeType;
-import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
-import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -15,7 +13,6 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
@@ -51,9 +48,9 @@ public class Card {
     @Column(nullable = false)
     private Platform platform;
 
-    private Double height;
+    private Integer height;
 
-    private Double weight;
+    private Integer weight;
 
     private Card(
             CardImage cardImage,
@@ -61,8 +58,8 @@ public class Card {
             String originId,
             Boolean isActive,
             Platform platform,
-            Double height,
-            Double weight
+            Integer height,
+            Integer weight
     ) {
         this.cardImage = cardImage;
         this.tags = tags;


### PR DESCRIPTION
## #️⃣연관된 이슈
[지라 티켓 링크](https://potenup-final.atlassian.net/browse/DK-120?atlOrigin=eyJpIjoiZGFlM2VmNWNiZjEzNDQ4Mjg5Mjc2MzNkOTQwNDhmZWYiLCJwIjoiaiJ9)

## 📝작업 내용
- Card 도메인의 키와 몸무게를 nullable한 integer로 정의했습니다
