### PR TITLE
[FEAT] crawl batch, raw 테이블 Repository 구현

### DIFF
--- a/src/main/java/com/dekk/crawl/infrastructure/CrawlBatchRepositoryImpl.java
+++ b/src/main/java/com/dekk/crawl/infrastructure/CrawlBatchRepositoryImpl.java
@@ -1,0 +1,25 @@
+package com.dekk.crawl.infrastructure;
+
+import com.dekk.crawl.domain.model.CrawlBatch;
+import com.dekk.crawl.domain.repository.CrawlBatchRepository;
+import com.dekk.crawl.infrastructure.jpa.CrawlBatchJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CrawlBatchRepositoryImpl implements CrawlBatchRepository {
+    private final CrawlBatchJpaRepository crawlBatchJpaRepository;
+
+    @Override
+    public CrawlBatch save(CrawlBatch batch) {
+        return crawlBatchJpaRepository.save(batch);
+    }
+
+    @Override
+    public Optional<CrawlBatch> findById(Long id) {
+        return crawlBatchJpaRepository.findById(id);
+    }
+}

--- a/src/main/java/com/dekk/crawl/infrastructure/CrawlRawDataRepositoryImpl.java
+++ b/src/main/java/com/dekk/crawl/infrastructure/CrawlRawDataRepositoryImpl.java
@@ -1,0 +1,40 @@
+package com.dekk.crawl.infrastructure;
+
+import com.dekk.crawl.domain.model.CrawlRawData;
+import com.dekk.crawl.domain.model.enums.RawDataStatus;
+import com.dekk.crawl.domain.repository.CrawlRawDataRepository;
+import com.dekk.crawl.infrastructure.jpa.CrawlRawDataJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class CrawlRawDataRepositoryImpl implements CrawlRawDataRepository {
+    private final CrawlRawDataJpaRepository crawlRawDataJpaRepository;
+
+    @Override
+    public CrawlRawData save(CrawlRawData rawData) {
+        return crawlRawDataJpaRepository.save(rawData);
+    }
+
+    @Override
+    public Optional<CrawlRawData> findById(Long id) {
+        return crawlRawDataJpaRepository.findById(id);
+    }
+
+    @Override
+    public List<CrawlRawData> findByStatusWithLimit(RawDataStatus status, int limit) {
+        Pageable pageable = PageRequest.of(0, limit);
+        return crawlRawDataJpaRepository.findByStatusOrderByIdAsc(status, pageable);
+    }
+
+    @Override
+    public long countByBatchIdAndStatusNot(Long batchId, RawDataStatus status) {
+        return crawlRawDataJpaRepository.countByBatchIdAndStatusNot(batchId, status);
+    }
+}

--- a/src/main/java/com/dekk/crawl/infrastructure/jpa/CrawlBatchJpaRepository.java
+++ b/src/main/java/com/dekk/crawl/infrastructure/jpa/CrawlBatchJpaRepository.java
@@ -1,0 +1,7 @@
+package com.dekk.crawl.infrastructure.jpa;
+
+import com.dekk.crawl.domain.model.CrawlBatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CrawlBatchJpaRepository extends JpaRepository<CrawlBatch, Long> {
+}

--- a/src/main/java/com/dekk/crawl/infrastructure/jpa/CrawlRawDataJpaRepository.java
+++ b/src/main/java/com/dekk/crawl/infrastructure/jpa/CrawlRawDataJpaRepository.java
@@ -1,0 +1,13 @@
+package com.dekk.crawl.infrastructure.jpa;
+
+import com.dekk.crawl.domain.model.CrawlRawData;
+import com.dekk.crawl.domain.model.enums.RawDataStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CrawlRawDataJpaRepository extends JpaRepository<CrawlRawData, Long> {
+    List<CrawlRawData> findByStatusOrderByIdAsc(RawDataStatus status, Pageable pageable);
+    long countByBatchIdAndStatusNot(Long batchId, RawDataStatus status);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
[지라 티켓 번호](https://potenup-final.atlassian.net/browse/DK-127)

## 📝작업 내용
- 크롤링 서버가 배치 생성 API 호출 시 배치를 db에 저장하기 위해 save()를 정의했습니다
- 배치 존재 여부 및 상태 검증을 위해 findById를 추가했습니다
- raw data 저장을 위해 save()를 정의했습니다
- raw data 조회를 위해 findById를 정의했습니다
- findByStatusWithLimit을 통해 단위 시간마다(ex 10분) 마다 PENDING 상태인 raw data를 N 건 조회해 옵니다. 페이지네이션을 쓸 수 없는 이유는 raw data 처리 이후 상태가 변경되기 때문에 N건을 가져오는 방식을 사용했어요!
- countByBatchIdAndStatusNot 은 Completed가 아닌 raw data 수를 카운트 해서 하나의 배치가 정상적으로 완료 되었는지 확인 하기 위한 용도입니다!