### PR TITLE
[FEAT] 카드 저장을 위한 repository 구현

### DIFF
--- a/src/main/java/com/dekk/card/domain/repository/CardRepository.java
+++ b/src/main/java/com/dekk/card/domain/repository/CardRepository.java
@@ -1,0 +1,12 @@
+package com.dekk.card.domain.repository;
+
+import com.dekk.card.domain.model.Card;
+import com.dekk.card.domain.model.enums.Platform;
+
+import java.util.List;
+
+public interface CardRepository {
+    Card save(Card card);
+    List<Card> saveAll(List<Card> cards);
+    boolean existsByPlatformAndOriginId(Platform platform, String originId);
+}

--- a/src/main/java/com/dekk/card/infrastructure/CardRepositoryImpl.java
+++ b/src/main/java/com/dekk/card/infrastructure/CardRepositoryImpl.java
@@ -1,0 +1,31 @@
+package com.dekk.card.infrastructure;
+
+import com.dekk.card.domain.model.Card;
+import com.dekk.card.domain.model.enums.Platform;
+import com.dekk.card.domain.repository.CardRepository;
+import com.dekk.card.infrastructure.jpa.CardJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class CardRepositoryImpl implements CardRepository {
+    private final CardJpaRepository cardJpaRepository;
+
+    @Override
+    public Card save(Card card) {
+        return cardJpaRepository.save(card);
+    }
+
+    @Override
+    public List<Card> saveAll(List<Card> cards) {
+        return cardJpaRepository.saveAll(cards);
+    }
+
+    @Override
+    public boolean existsByPlatformAndOriginId(Platform platform, String originId) {
+        return cardJpaRepository.existsByPlatformAndOriginId(platform, originId);
+    }
+}

--- a/src/main/java/com/dekk/card/infrastructure/jpa/CardJpaRepository.java
+++ b/src/main/java/com/dekk/card/infrastructure/jpa/CardJpaRepository.java
@@ -1,0 +1,9 @@
+package com.dekk.card.infrastructure.jpa;
+
+import com.dekk.card.domain.model.Card;
+import com.dekk.card.domain.model.enums.Platform;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CardJpaRepository extends JpaRepository<Card, Long> {
+    boolean existsByPlatformAndOriginId(Platform platform, String originId);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
[지라 티켓 번호](https://potenup-final.atlassian.net/browse/DK-38)

## 📝작업 내용
- 카드 저장을 위한 Jpa Repository와 인터페이스, 구현체를 작성했습니다!