### PR TITLE
[CHORE] lint 적용 (spotless + palantirJavaFormat 버전)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.11'
 	id 'io.spring.dependency-management' version '1.1.7'
+    id "com.diffplug.spotless" version "8.3.0"
 }
 
 group = 'com.dekk'
@@ -19,6 +20,21 @@ configurations {
 		extendsFrom annotationProcessor
 	}
 }
+
+spotless {
+    java {
+        target 'src/main/java/**/*.java'
+
+        removeUnusedImports()   // 사용하지 않는 import문 자동 삭제
+        importOrder('java', 'javax', 'org', 'com', '')
+
+        palantirJavaFormat()
+
+        trimTrailingWhitespace() // 문장 끝 불필요한 공백 제거
+        endWithNewline()        // 파일 끝에 빈 줄 추가 (Git 관리 표준)
+    }
+}
+
 tasks.named('jar') {
     enabled = false
 }


### PR DESCRIPTION
> 현재 build가 되지 않는것은 build.gradle을 변경했는데 spotless 적용을 하지 않아서 나는 이슈입니다! 
> 추후 적용이 된다면 한번에 많은 파일들이 수정될 것 같습니다.
> 2차 Release 직전에 한 번 돌리고 병합하면 될 것 같습니다.


## 상황
모두가 일관된 코드 컨벤션을 위해 lint를 적용하기로 하였습니다.

## 적용 lint
- spotless
- palantirJavaFormat

## 예시
### 체이닝
```java
return users.stream()
            .filter(u -> u.isActive())
            .map(u -> u.getProfile())
            .orElseThrow(() -> new NotFoundException());
```
### record class
```java
// Palantir: 최대한 한 줄로 밀어넣음
public record CardImageCreateCommand(String originUrl, String imageUrl, boolean isUploaded) {
    private final String metadata; // 클래스 헤더 바로 아래 공백 없음
}
```