### PR TITLE
[FEAT] 카테고리 엔티티 도메인 

### DIFF
--- a/src/main/java/com/dekk/category/domain/exception/CategoryBusinessException.java
+++ b/src/main/java/com/dekk/category/domain/exception/CategoryBusinessException.java
@@ -1,0 +1,10 @@
+package com.dekk.category.domain.exception;
+
+import com.dekk.common.error.BusinessException;
+import com.dekk.common.error.ErrorCode;
+
+public class CategoryBusinessException extends BusinessException {
+    public CategoryBusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/dekk/category/domain/exception/CategoryErrorCode.java
+++ b/src/main/java/com/dekk/category/domain/exception/CategoryErrorCode.java
@@ -1,0 +1,28 @@
+package com.dekk.category.domain.exception;
+
+import com.dekk.common.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public enum CategoryErrorCode implements ErrorCode {
+    CATEGORY_NAME_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ECT40001", "카테고리 이름은 필수값입니다"),
+    CATEGORY_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "ECT40002", "카테고리 이름은 10자 이내여야 합니다"),
+    PARENT_CATEGORY_REQUIRED(HttpStatus.BAD_REQUEST, "ECT40003", "하위 카테고리 생성 시 상위 카테고리는 필수입니다"),
+    ONLY_PARENT_CAN_HAVE_CHILDREN(HttpStatus.BAD_REQUEST, "ECT40004", "상위 카테고리만 하위 카테고리를 가질 수 있습니다"),
+    ONLY_CHILD_CATEGORY_CAN_MAP_CARD(HttpStatus.BAD_REQUEST, "ECT40005", "하위 카테고리만 카드에 매핑할 수 있습니다"),
+    CARD_ALREADY_IN_CATEGORY(HttpStatus.BAD_REQUEST, "ECT40006", "이미 해당 카테고리에 포함된 카드입니다"),
+    CARD_ID_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ECT40007", "카드 ID는 필수값입니다"),
+    CATEGORY_ID_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ECT40008", "카테고리 ID는 필수값입니다"),
+
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "ECT40401", "카테고리를 찾을 수 없습니다"),
+    CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "ECT40402", "카드를 찾을 수 없습니다");
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override public HttpStatus status() { return httpStatus; }
+    @Override public String code() { return code; }
+    @Override public String message() { return message; }
+}

--- a/src/main/java/com/dekk/category/domain/model/CardCategory.java
+++ b/src/main/java/com/dekk/category/domain/model/CardCategory.java
@@ -1,0 +1,50 @@
+package com.dekk.category.domain.model;
+
+import com.dekk.category.domain.exception.CategoryBusinessException;
+import com.dekk.category.domain.exception.CategoryErrorCode;
+import com.dekk.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.SQLDelete;
+
+@Entity
+@Table(name = "card_categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE card_categories SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Filter(name = "deletedFilter")
+public class CardCategory extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "card_id", nullable = false)
+    private Long cardId;
+
+    @Column(name = "category_id", nullable = false)
+    private Long categoryId;
+
+    private CardCategory(Long cardId, Long categoryId) {
+        this.cardId = cardId;
+        this.categoryId = categoryId;
+    }
+
+    public static CardCategory create(Long cardId, Long categoryId) {
+        if (cardId == null) {
+            throw new CategoryBusinessException(CategoryErrorCode.CARD_ID_IS_REQUIRED);
+        }
+        if (categoryId == null) {
+            throw new CategoryBusinessException(CategoryErrorCode.CATEGORY_ID_IS_REQUIRED);
+        }
+        return new CardCategory(cardId, categoryId);
+    }
+}

--- a/src/main/java/com/dekk/category/domain/model/Category.java
+++ b/src/main/java/com/dekk/category/domain/model/Category.java
@@ -1,0 +1,97 @@
+package com.dekk.category.domain.model;
+
+import com.dekk.category.domain.exception.CategoryBusinessException;
+import com.dekk.category.domain.exception.CategoryErrorCode;
+import com.dekk.common.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.SQLDelete;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE categories SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Filter(name = "deletedFilter")
+public class Category extends BaseTimeEntity {
+
+    private static final int MAX_NAME_LENGTH = 10;
+    private static final int PARENT_DEPTH = 0;
+    private static final int CHILD_DEPTH = 1;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
+    private Category parent;
+
+    @OneToMany(mappedBy = "parent")
+    private List<Category> children = new ArrayList<>();
+
+    @Column(nullable = false, length = MAX_NAME_LENGTH)
+    private String name;
+
+    @Column(nullable = false)
+    private int depth;
+
+    private Category(Category parent, String name, int depth) {
+        this.parent = parent;
+        this.name = name;
+        this.depth = depth;
+    }
+
+    public static Category createParent(String name) {
+        validateName(name);
+        return new Category(null, name, PARENT_DEPTH);
+    }
+
+    public static Category createChild(Category parent, String name) {
+        validateName(name);
+        if (parent == null) {
+            throw new CategoryBusinessException(CategoryErrorCode.PARENT_CATEGORY_REQUIRED);
+        }
+        if (parent.getDepth() != PARENT_DEPTH) {
+            throw new CategoryBusinessException(CategoryErrorCode.ONLY_PARENT_CAN_HAVE_CHILDREN);
+        }
+        return new Category(parent, name, CHILD_DEPTH);
+    }
+
+    public void updateName(String name) {
+        validateName(name);
+        this.name = name;
+    }
+
+    public boolean isParent() {
+        return this.depth == PARENT_DEPTH;
+    }
+
+    public boolean isChild() {
+        return this.depth == CHILD_DEPTH;
+    }
+
+    private static void validateName(String name) {
+        if (name == null || name.isBlank()) {
+            throw new CategoryBusinessException(CategoryErrorCode.CATEGORY_NAME_IS_REQUIRED);
+        }
+        if (name.length() > MAX_NAME_LENGTH) {
+            throw new CategoryBusinessException(CategoryErrorCode.CATEGORY_NAME_TOO_LONG);
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
[지라 티켓 번호](https://potenup-final.atlassian.net/browse/DK-220)

## 📝작업 내용
- 기존에 hard delete로 작업한 Category 관련 엔티티 도메인을 soft delete 방식으로변경했습니다
- 변경 이유는 코드 리뷰를 받으며 아래와 같은 이유로 도입하게 되었습니다
  - BaseTimeEntity와 deletedAt을 사용하는 기존 코드의 컨벤션을 따름
  - 실수로 상위 카테고리 삭제 시 하위 카테고리 복구가 안되는 상황이 발생하는 걸 막기 위해
  - 통계 데이터, 업데이트 추적 등
- 기존에 제 PR은 layer 별로 요청을 드렸었는데 repository 코드가 어디에 어떻게 쓰일지 모르는 상황에서 PR을 요청 드린 것 같아 방식을 변경하고 싶었습니다! 