### PR TITLE
[FEAT] Admin 도메인 기반 구조 생성

### DIFF
--- a/src/main/java/com/dekk/admin/domain/exception/AdminBusinessException.java
+++ b/src/main/java/com/dekk/admin/domain/exception/AdminBusinessException.java
@@ -1,0 +1,10 @@
+package com.dekk.admin.domain.exception;
+
+import com.dekk.common.error.BusinessException;
+import com.dekk.common.error.ErrorCode;
+
+public class AdminBusinessException extends BusinessException {
+    public AdminBusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/dekk/admin/domain/exception/AdminErrorCode.java
+++ b/src/main/java/com/dekk/admin/domain/exception/AdminErrorCode.java
@@ -1,0 +1,39 @@
+package com.dekk.admin.domain.exception;
+
+import com.dekk.common.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminErrorCode implements ErrorCode {
+    INVALID_ADMIN_DATA(HttpStatus.BAD_REQUEST, "EADM40001", "관리자 필수 정보가 누락되었거나 올바르지 않습니다."),
+
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "EADM40101", "비밀번호가 일치하지 않습니다."),
+
+    UNAUTHORIZED_ROLE(HttpStatus.FORBIDDEN, "EADM40301", "권한이 없습니다."),
+
+    ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "EADM40401", "관리자를 찾을 수 없습니다."),
+
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "EADM40901", "이미 등록된 이메일입니다.");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    @Override
+    public HttpStatus status() {
+        return status;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/com/dekk/admin/domain/model/Admin.java
+++ b/src/main/java/com/dekk/admin/domain/model/Admin.java
@@ -1,0 +1,65 @@
+package com.dekk.admin.domain.model;
+
+import com.dekk.admin.domain.exception.AdminBusinessException;
+import com.dekk.admin.domain.exception.AdminErrorCode;
+import com.dekk.common.entity.BaseTimeEntity;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.hibernate.annotations.Filter;
+import org.hibernate.annotations.SQLDelete;
+
+@Entity
+@Table(
+        name = "admins",
+        uniqueConstraints = {@UniqueConstraint(name = "uk_admin_email", columnNames = "email")}
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE admins SET deleted_at = CURRENT_TIMESTAMP WHERE id = ?")
+@Filter(name = "deletedFilter")
+public class Admin extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String email;
+
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private AdminRole adminRole;
+
+    private Admin(String email, String password, AdminRole adminRole) {
+        this.email = email;
+        this.password = password;
+        this.adminRole = adminRole;
+    }
+
+    public static Admin create(String email, String encodedPassword, AdminRole adminRole) {
+        validate(email, encodedPassword, adminRole);
+        return new Admin(email, encodedPassword, adminRole);
+    }
+
+    private static void validate(String email, String encodedPassword, AdminRole adminRole) {
+        if (email == null || email.isBlank()) {
+            throw new AdminBusinessException(AdminErrorCode.INVALID_ADMIN_DATA);
+        }
+        if (encodedPassword == null || encodedPassword.isBlank()) {
+            throw new AdminBusinessException(AdminErrorCode.INVALID_ADMIN_DATA);
+        }
+        if (adminRole == null) {
+            throw new AdminBusinessException(AdminErrorCode.INVALID_ADMIN_DATA);
+        }
+    }
+}

--- a/src/main/java/com/dekk/admin/domain/model/AdminRole.java
+++ b/src/main/java/com/dekk/admin/domain/model/AdminRole.java
@@ -1,0 +1,14 @@
+package com.dekk.admin.domain.model;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AdminRole {
+    SUPER_ADMIN("SUPER_ADMIN","'슈퍼 관리자 권한"),
+    ADMIN("ADMIN","관리자 권한");
+
+    private final String key;
+    private final String title;
+}

--- a/src/main/java/com/dekk/admin/domain/repository/AdminRepository.java
+++ b/src/main/java/com/dekk/admin/domain/repository/AdminRepository.java
@@ -1,0 +1,11 @@
+package com.dekk.admin.domain.repository;
+
+import com.dekk.admin.domain.model.Admin;
+import java.util.Optional;
+
+public interface AdminRepository {
+    Admin save(Admin admin);
+    Optional<Admin> findByEmail(String email);
+    boolean existsByEmail(String email);
+    Optional<Admin> findById(Long id);
+}

--- a/src/main/java/com/dekk/admin/infrastructure/AdminRepositoryImpl.java
+++ b/src/main/java/com/dekk/admin/infrastructure/AdminRepositoryImpl.java
@@ -1,0 +1,36 @@
+package com.dekk.admin.infrastructure;
+
+import com.dekk.admin.domain.model.Admin;
+import com.dekk.admin.domain.repository.AdminRepository;
+import com.dekk.admin.infrastructure.jpa.AdminJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AdminRepositoryImpl implements AdminRepository {
+
+    private final AdminJpaRepository adminJpaRepository;
+
+    @Override
+    public Admin save(Admin admin) {
+        return adminJpaRepository.save(admin);
+    }
+
+    @Override
+    public Optional<Admin> findByEmail(String email) {
+        return adminJpaRepository.findByEmail(email);
+    }
+
+    @Override
+    public boolean existsByEmail(String email) {
+        return adminJpaRepository.existsByEmail(email);
+    }
+
+    @Override
+    public Optional<Admin> findById(Long id) {
+        return adminJpaRepository.findById(id);
+    }
+}

--- a/src/main/java/com/dekk/admin/infrastructure/jpa/AdminJpaRepository.java
+++ b/src/main/java/com/dekk/admin/infrastructure/jpa/AdminJpaRepository.java
@@ -1,0 +1,10 @@
+package com.dekk.admin.infrastructure.jpa;
+
+import com.dekk.admin.domain.model.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.Optional;
+
+public interface AdminJpaRepository extends JpaRepository<Admin, Long> {
+    Optional<Admin> findByEmail(String email);
+    boolean existsByEmail(String email);
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
[DK-196](https://potenup-final.atlassian.net/browse/DK-197?atlOrigin=eyJpIjoiY2YzYmQzM2I2ZjE0NGIzNmExYmVjMTIzYWQxMDg2ZDYiLCJwIjoiaiJ9)

## 📝작업 내용

- Admin 엔티티 생성 (BaseTimeEntity 상속)

- 기본 생성자 Protected 접근 제어 및 정적 팩토리 메서드(create) 구현

- @SQLDelete 및 @Filter를 활용한 Soft Delete 적용

- 관리자 권한 레벨 Enum 정의 (EnumType.STRING 적용)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


[DK-196]: https://potenup-final.atlassian.net/browse/DK-196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ