### PR TITLE
feat: Redis 기반 Refresh Token 관리 및 RTR 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     testImplementation 'com.h2database:h2'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,15 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
 
+  redis:
+    image: redis:7-alpine
+    container_name: dekk-redis
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
 volumes:
   postgres_data:
+  redis_data:

--- a/src/main/java/com/dekk/auth/application/AuthCommandService.java
+++ b/src/main/java/com/dekk/auth/application/AuthCommandService.java
@@ -2,7 +2,12 @@ package com.dekk.auth.application;
 
 import com.dekk.auth.application.command.TokenRefreshCommand;
 import com.dekk.auth.application.dto.result.TokenRefreshResult;
+import com.dekk.auth.domain.exception.AuthBusinessException;
+import com.dekk.auth.domain.exception.AuthErrorCode;
+import com.dekk.auth.domain.model.RefreshToken;
+import com.dekk.auth.domain.repository.RefreshTokenRepository;
 import com.dekk.auth.jwt.JwtTokenProvider;
+import com.dekk.security.oauth2.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Service;
@@ -12,15 +17,36 @@ import org.springframework.stereotype.Service;
 public class AuthCommandService {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     public TokenRefreshResult refreshToken(TokenRefreshCommand command) {
         jwtTokenProvider.validateToken(command.refreshToken());
 
-        Authentication authentication = jwtTokenProvider.getAuthentication((command.refreshToken()));
+        if (!jwtTokenProvider.isRefreshToken(command.refreshToken())) {
+            throw new AuthBusinessException(AuthErrorCode.INVALID_TOKEN_TYPE);
+        }
+
+        Authentication authentication = jwtTokenProvider.getAuthentication(command.refreshToken());
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+        Long userId = userDetails.getId();
+
+        RefreshToken savedRefreshToken = refreshTokenRepository.findByUserId(userId)
+                .orElseThrow(() -> new AuthBusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN));
+
+        if (!savedRefreshToken.getToken().equals(command.refreshToken())) {
+            refreshTokenRepository.deleteByUserId(userId);
+            throw new AuthBusinessException(AuthErrorCode.ABNORMAL_TOKEN_ACCESS);
+        }
 
         String newAccessToken = jwtTokenProvider.createAccessToken(authentication);
         String newRefreshToken = jwtTokenProvider.createRefreshToken(authentication);
 
+        refreshTokenRepository.save(RefreshToken.create(userId, newRefreshToken));
+
         return new TokenRefreshResult(newAccessToken, newRefreshToken);
+    }
+
+    public void logout(Long userId) {
+        refreshTokenRepository.deleteByUserId(userId);
     }
 }

--- a/src/main/java/com/dekk/auth/application/command/TokenRefreshCommand.java
+++ b/src/main/java/com/dekk/auth/application/command/TokenRefreshCommand.java
@@ -1,13 +1,6 @@
 package com.dekk.auth.application.command;
 
-import com.dekk.auth.domain.exception.AuthBusinessException;
-import com.dekk.auth.domain.exception.AuthErrorCode;
-import org.springframework.util.StringUtils;
-
-public record TokenRefreshCommand(String refreshToken) {
-    public TokenRefreshCommand {
-        if (!StringUtils.hasText(refreshToken)) {
-            throw new AuthBusinessException(AuthErrorCode.INVALID_TOKEN);
-        }
-    }
+public record TokenRefreshCommand(
+        String refreshToken
+) {
 }

--- a/src/main/java/com/dekk/auth/domain/exception/AuthErrorCode.java
+++ b/src/main/java/com/dekk/auth/domain/exception/AuthErrorCode.java
@@ -10,7 +10,11 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "EA40101", "유효하지 않은 JWT 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EA40102", "만료된 JWT 토큰입니다."),
     UNSUPPORTED_TOKEN(HttpStatus.UNAUTHORIZED, "EA40103", "지원되지 않는 JWT 토큰입니다."),
-    EMPTY_CLAIMS(HttpStatus.UNAUTHORIZED, "EA40104", "JWT 클레임 문자열이 비어 있습니다.");
+    EMPTY_CLAIMS(HttpStatus.UNAUTHORIZED, "EA40104", "JWT 클레임 문자열이 비어 있습니다."),
+    INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "EA40105", "유효하지 않은 리프레시 토큰입니다."),
+    INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "EA40107", "잘못된 타입의 JWT 토큰 유형입니다."),
+
+    ABNORMAL_TOKEN_ACCESS(HttpStatus.FORBIDDEN, "EA40301", "비정상적인 토큰 접근이 감지되었습니다. 모든 기기에서 로그아웃됩니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/dekk/auth/domain/model/RefreshToken.java
+++ b/src/main/java/com/dekk/auth/domain/model/RefreshToken.java
@@ -1,0 +1,27 @@
+package com.dekk.auth.domain.model;
+
+import com.dekk.auth.domain.exception.AuthBusinessException;
+import com.dekk.auth.domain.exception.AuthErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken {
+
+    private Long userId;
+    private String token;
+
+    private RefreshToken(Long userId, String token) {
+        this.userId = userId;
+        this.token = token;
+    }
+
+    public static RefreshToken create(Long userId, String token) {
+        if(userId == null || token == null || token.isBlank()) {
+            throw new AuthBusinessException(AuthErrorCode.INVALID_REFRESH_TOKEN);
+        }
+        return new RefreshToken(userId, token);
+    }
+}

--- a/src/main/java/com/dekk/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/dekk/auth/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package com.dekk.auth.domain.repository;
+
+import com.dekk.auth.domain.model.RefreshToken;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository {
+    void save(RefreshToken refreshToken);
+    Optional<RefreshToken> findByUserId(Long userId);
+    void deleteByUserId(Long userId);
+}

--- a/src/main/java/com/dekk/auth/infrastructure/redis/RefreshTokenRepositoryImpl.java
+++ b/src/main/java/com/dekk/auth/infrastructure/redis/RefreshTokenRepositoryImpl.java
@@ -1,0 +1,59 @@
+package com.dekk.auth.infrastructure.redis;
+
+import com.dekk.auth.domain.model.RefreshToken;
+import com.dekk.auth.domain.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepositoryImpl implements RefreshTokenRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String PREFIX = "RT:";
+
+    @Value("${jwt.refresh-token-validity-in-seconds}")
+    private long refreshTokenTtlSeconds;
+
+    @Override
+    public void save(RefreshToken refreshToken) {
+        String key = PREFIX + refreshToken.getUserId();
+        try {
+            redisTemplate.opsForValue().set(key, refreshToken.getToken(), refreshTokenTtlSeconds, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] Refresh Token 저장 실패 - UserId: {}, Reason: {}", refreshToken.getUserId(), e.getMessage());
+        }
+    }
+
+    @Override
+    public Optional<RefreshToken> findByUserId(Long userId) {
+        String key = PREFIX + userId;
+        try {
+            String token = redisTemplate.opsForValue().get(key);
+            if (token == null) {
+                return Optional.empty();
+            }
+            return Optional.of(RefreshToken.create(userId, token));
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] Refresh Token 조회 실패 - UserId: {}, Reason: {}", userId, e.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    @Override
+    public void deleteByUserId(Long userId) {
+        String key = PREFIX + userId;
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] Refresh Token 삭제 실패 - UserId: {}, Reason: {}", userId, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/dekk/auth/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dekk/auth/jwt/JwtTokenProvider.java
@@ -28,8 +28,11 @@ import java.util.stream.Collectors;
 public class JwtTokenProvider {
 
     private static final String AUTHORITIES_KEY = "auth";
-    private final Key key;
+    private static final String TOKEN_TYPE_KEY = "type";
+    private static final String ACCESS_TOKEN_TYPE = "ACCESS";
+    private static final String REFRESH_TOKEN_TYPE = "REFRESH";
 
+    private final Key key;
     private final long accessTokenValidityTime;
     private final long refreshTokenValidityTime;
 
@@ -45,14 +48,14 @@ public class JwtTokenProvider {
     }
 
     public String createAccessToken(Authentication authentication) {
-        return createToken(authentication, accessTokenValidityTime);
+        return createToken(authentication, accessTokenValidityTime, ACCESS_TOKEN_TYPE);
     }
 
     public String createRefreshToken(Authentication authentication) {
-        return createToken(authentication, refreshTokenValidityTime);
+        return createToken(authentication, refreshTokenValidityTime, REFRESH_TOKEN_TYPE);
     }
 
-    private String createToken(Authentication authentication, long tokenValidTime) {
+    private String createToken(Authentication authentication, long tokenValidTime, String tokenType) {
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
@@ -70,17 +73,24 @@ public class JwtTokenProvider {
                 .claim(AUTHORITIES_KEY, authorities)
                 .claim("userId", userId)
                 .claim("status", status)
+                .claim(TOKEN_TYPE_KEY, tokenType)
                 .signWith(key, SignatureAlgorithm.HS256)
                 .setExpiration(validity)
                 .compact();
     }
 
+    public boolean isAccessToken(String token) {
+        String type = getClaims(token).get(TOKEN_TYPE_KEY, String.class);
+        return ACCESS_TOKEN_TYPE.equals(type);
+    }
+
+    public boolean isRefreshToken(String token) {
+        String type = getClaims(token).get(TOKEN_TYPE_KEY, String.class);
+        return REFRESH_TOKEN_TYPE.equals(type);
+    }
+
     public Authentication getAuthentication(String token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+        Claims claims = getClaims(token);
 
         String role = claims.get(AUTHORITIES_KEY).toString();
 
@@ -100,7 +110,7 @@ public class JwtTokenProvider {
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            getClaims(token);
             return true;
         } catch (SecurityException | MalformedJwtException e) {
             throw new AuthBusinessException(AuthErrorCode.INVALID_TOKEN);
@@ -111,5 +121,24 @@ public class JwtTokenProvider {
         } catch (IllegalArgumentException e) {
             throw new AuthBusinessException(AuthErrorCode.EMPTY_CLAIMS);
         }
+    }
+
+    public long getRemainingExpirationTime(String token) {
+        try {
+            Date expiration = getClaims(token).getExpiration();
+            long now = (new Date()).getTime();
+            long remainingMillis = expiration.getTime() - now;
+            return remainingMillis > 0 ? remainingMillis / 1000 : 0;
+        } catch (ExpiredJwtException e) {
+            return 0;
+        }
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(key)
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
     }
 }

--- a/src/main/java/com/dekk/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dekk/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,13 +1,12 @@
 package com.dekk.auth.jwt.filter;
 
+import com.dekk.auth.domain.exception.AuthErrorCode;
 import com.dekk.auth.jwt.JwtTokenProvider;
 import com.dekk.auth.domain.exception.AuthBusinessException;
-import com.dekk.auth.presentation.util.CookieUtil;
 import com.dekk.common.error.ErrorResponse;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +18,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Component
@@ -34,7 +32,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String jwt = resolveTokenFromCookie(request);
+        String jwt = resolveToken(request);
 
         if (!StringUtils.hasText(jwt)) {
             filterChain.doFilter(request, response);
@@ -43,6 +41,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         try {
             if (jwtTokenProvider.validateToken(jwt)) {
+                if(!jwtTokenProvider.isAccessToken(jwt)) {
+                    throw new AuthBusinessException(AuthErrorCode.INVALID_TOKEN_TYPE);
+                }
+
                 Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
@@ -53,14 +55,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         filterChain.doFilter(request, response);
     }
 
-    private String resolveTokenFromCookie(HttpServletRequest request) {
-        Cookie[] cookies = request.getCookies();
-        if (cookies != null) {
-            return Arrays.stream(cookies)
-                    .filter(cookie -> CookieUtil.ACCESS_TOKEN_NAME.equals(cookie.getName()))
-                    .map(Cookie::getValue)
-                    .findFirst()
-                    .orElse(null);
+    private String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(AUTHORIZATION_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER_PREFIX)) {
+            return bearerToken.substring(BEARER_PREFIX.length());
         }
         return null;
     }

--- a/src/main/java/com/dekk/auth/presentation/controller/AuthApi.java
+++ b/src/main/java/com/dekk/auth/presentation/controller/AuthApi.java
@@ -1,32 +1,42 @@
 package com.dekk.auth.presentation.controller;
 
+import com.dekk.auth.presentation.request.TokenRefreshRequest;
+import com.dekk.auth.presentation.response.TokenResponse;
 import com.dekk.common.response.ApiResponse;
+import com.dekk.security.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.servlet.http.HttpServletResponse;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
-@Tag(name = "인증 API", description = "토큰 재발급 및 로그아웃 API (HttpOnly 쿠키 기반)")
+@Tag(name = "인증 API", description = "토큰 재발급 및 로그아웃 API")
 public interface AuthApi {
 
-    @Operation(summary = "토큰 재발급", description = "쿠키에 담긴 리프레시 토큰을 검증하여 새로운 액세스/리프레시 토큰 쿠키를 발급합니다.")
+    @Operation(summary = "토큰 재발급", description = "리프레시 토큰으로 액세스 토큰과 리프레시 토큰을 재발급합니다.")
     @ApiResponses(value = {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SA20001)"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "유효하지 않은 토큰(EA40101)")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "401",
+                    description = "유효하지 않은 토큰(EA40101) / 만료된 토큰(EA40102) / 지원되지 않는 토큰(EA40103) / 빈 클레임(EA40104)",
+                    content = @Content(schema = @Schema(implementation = com.dekk.common.error.ErrorResponse.class))
+            )
     })
-    ResponseEntity<ApiResponse<Void>> refreshToken(
-            @Parameter(hidden = true) @CookieValue(value = "refresh_token") String refreshToken,
-            @Parameter(hidden = true) HttpServletResponse response
+    ResponseEntity<ApiResponse<TokenResponse>> refreshToken(
+            @Valid @RequestBody TokenRefreshRequest request
     );
 
-    @Operation(summary = "로그아웃", description = "발급된 인증 쿠키를 모두 삭제(만료) 처리합니다.")
+    @Operation(summary = "로그아웃", description = "로그아웃을 처리하여 Refresh Token을 삭제하고 Access Token을 무효화합니다.")
     @ApiResponses(value = {
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "로그아웃 성공 (SA20002)")
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SA20002)")
     })
     ResponseEntity<ApiResponse<Void>> logout(
-            @Parameter(hidden = true) HttpServletResponse response
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(hidden = true) @RequestHeader("Authorization") String authorizationHeader
     );
 }

--- a/src/main/java/com/dekk/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/dekk/auth/presentation/controller/AuthController.java
@@ -1,56 +1,49 @@
 package com.dekk.auth.presentation.controller;
 
 import com.dekk.auth.application.AuthCommandService;
-import com.dekk.auth.application.command.TokenRefreshCommand;
 import com.dekk.auth.application.dto.result.TokenRefreshResult;
+import com.dekk.auth.presentation.request.TokenRefreshRequest;
 import com.dekk.auth.presentation.response.AuthResultCode;
-import com.dekk.auth.presentation.util.CookieUtil;
+import com.dekk.auth.presentation.response.TokenResponse;
 import com.dekk.common.response.ApiResponse;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Value;
+import com.dekk.security.oauth2.CustomUserDetails;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/w/v1/auth")
+@RequiredArgsConstructor
 public class AuthController implements AuthApi {
 
     private final AuthCommandService authCommandService;
-    private final int accessTokenMaxAge;
-    private final int refreshTokenMaxAge;
-
-    public AuthController(
-            AuthCommandService authCommandService,
-            @Value("${jwt.access-token-validity-in-seconds}") int accessTokenMaxAge,
-            @Value("${jwt.refresh-token-validity-in-seconds}") int refreshTokenMaxAge) {
-        this.authCommandService = authCommandService;
-        this.accessTokenMaxAge = accessTokenMaxAge;
-        this.refreshTokenMaxAge = refreshTokenMaxAge;
-    }
+    private static final String BEARER_PREFIX = "Bearer ";
 
     @Override
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse<Void>> refreshToken(
-            @CookieValue(value = CookieUtil.REFRESH_TOKEN_NAME, required = false) String refreshToken,
-            HttpServletResponse response
+    public ResponseEntity<ApiResponse<TokenResponse>> refreshToken(
+            @Valid @RequestBody TokenRefreshRequest request
     ) {
-        TokenRefreshResult result = authCommandService.refreshToken(new TokenRefreshCommand(refreshToken));
+        TokenRefreshResult result = authCommandService.refreshToken(request.toCommand());
 
-        CookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, result.accessToken(), accessTokenMaxAge);
-        CookieUtil.addCookie(response, CookieUtil.REFRESH_TOKEN_NAME, result.refreshToken(), refreshTokenMaxAge);
-
-        return ResponseEntity.ok(ApiResponse.from(AuthResultCode.TOKEN_REFRESH_SUCCESS));
+        return ResponseEntity.ok(ApiResponse.of(AuthResultCode.REISSUE_SUCCESS, TokenResponse.from(result)));
     }
 
     @Override
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        String accessToken = authorizationHeader.substring(BEARER_PREFIX.length());
 
-        CookieUtil.deleteCookie(response, CookieUtil.ACCESS_TOKEN_NAME);
-        CookieUtil.deleteCookie(response, CookieUtil.REFRESH_TOKEN_NAME);
+        authCommandService.logout(userDetails.getId());
 
         return ResponseEntity.ok(ApiResponse.from(AuthResultCode.LOGOUT_SUCCESS));
     }

--- a/src/main/java/com/dekk/auth/presentation/request/TokenRefreshRequest.java
+++ b/src/main/java/com/dekk/auth/presentation/request/TokenRefreshRequest.java
@@ -1,0 +1,13 @@
+package com.dekk.auth.presentation.request;
+
+import com.dekk.auth.application.command.TokenRefreshCommand;
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank(message = "Refresh Token은 필수입니다.")
+        String refreshToken
+) {
+    public TokenRefreshCommand toCommand() {
+        return new TokenRefreshCommand(refreshToken);
+    }
+}

--- a/src/main/java/com/dekk/auth/presentation/response/AuthResultCode.java
+++ b/src/main/java/com/dekk/auth/presentation/response/AuthResultCode.java
@@ -6,13 +6,12 @@ import org.springframework.http.HttpStatus;
 
 @RequiredArgsConstructor
 public enum AuthResultCode implements ResultCode {
-    TOKEN_REFRESH_SUCCESS(HttpStatus.OK, "SA20001", "토큰 재발급 성공"),
-    LOGOUT_SUCCESS(HttpStatus.OK, "SA20002", "로그아웃 성공");
+    REISSUE_SUCCESS(HttpStatus.OK, "SA20001", "토큰 재발급에 성공했습니다."),
+    LOGOUT_SUCCESS(HttpStatus.OK, "SA20002", "로그아웃에 성공했습니다.");
 
     private final HttpStatus status;
     private final String code;
     private final String message;
-
 
     @Override
     public HttpStatus status() {

--- a/src/main/java/com/dekk/auth/presentation/response/TokenResponse.java
+++ b/src/main/java/com/dekk/auth/presentation/response/TokenResponse.java
@@ -1,0 +1,12 @@
+package com.dekk.auth.presentation.response;
+
+import com.dekk.auth.application.dto.result.TokenRefreshResult;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {
+    public static TokenResponse from(TokenRefreshResult result){
+        return new TokenResponse(result.accessToken(), result.refreshToken());
+    }
+}

--- a/src/main/java/com/dekk/card/application/CardQueryService.java
+++ b/src/main/java/com/dekk/card/application/CardQueryService.java
@@ -1,9 +1,7 @@
 package com.dekk.card.application;
 
-import com.dekk.card.application.dto.query.RecommendCandidateQuery;
 import com.dekk.card.application.dto.result.GuestCardResult;
 import com.dekk.card.application.dto.result.MemberCardResult;
-import com.dekk.card.domain.model.Card;
 import com.dekk.card.domain.model.enums.CardStatus;
 import com.dekk.card.domain.repository.CardRepository;
 import lombok.RequiredArgsConstructor;
@@ -38,9 +36,5 @@ public class CardQueryService {
         return cardRepository.findAllByIdInWithProducts(ids).stream()
             .map(MemberCardResult::from)
             .toList();
-    }
-
-    public List<Card> getRecommendCandidates(RecommendCandidateQuery query) {
-        return cardRepository.findRecommendCandidates(query);
     }
 }

--- a/src/main/java/com/dekk/card/application/command/CardCreateCommand.java
+++ b/src/main/java/com/dekk/card/application/command/CardCreateCommand.java
@@ -2,7 +2,6 @@ package com.dekk.card.application.command;
 
 import com.dekk.card.domain.model.enums.Platform;
 
-import com.dekk.card.domain.model.enums.TargetGender;
 import java.util.List;
 
 public record CardCreateCommand(
@@ -11,7 +10,6 @@ public record CardCreateCommand(
     String tags,
     String originId,
     Platform platform,
-    TargetGender targetGender,
     Integer height,
     Integer weight
 ) {

--- a/src/main/java/com/dekk/card/domain/model/Card.java
+++ b/src/main/java/com/dekk/card/domain/model/Card.java
@@ -5,7 +5,6 @@ import com.dekk.card.domain.exception.CardBusinessException;
 import com.dekk.card.domain.exception.CardErrorCode;
 import com.dekk.card.domain.model.enums.CardStatus;
 import com.dekk.card.domain.model.enums.Platform;
-import com.dekk.card.domain.model.enums.TargetGender;
 import com.dekk.common.entity.BaseTimeEntity;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -54,10 +53,6 @@ public class Card extends BaseTimeEntity {
     @Column(nullable = false)
     private Platform platform;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "target_gender")
-    private TargetGender targetGender;
-
     private Integer height;
 
     private Integer weight;
@@ -67,7 +62,6 @@ public class Card extends BaseTimeEntity {
             String tags,
             String originId,
             Platform platform,
-            TargetGender targetGender,
             Integer height,
             Integer weight
     ) {
@@ -76,7 +70,6 @@ public class Card extends BaseTimeEntity {
         this.originId = originId;
         this.status = CardStatus.PENDING;
         this.platform = platform;
-        this.targetGender = targetGender;
         this.height = height;
         this.weight = weight;
     }
@@ -93,7 +86,6 @@ public class Card extends BaseTimeEntity {
                 command.tags(),
                 command.originId(),
                 command.platform(),
-                command.targetGender(),
                 command.height(),
                 command.weight()
         );

--- a/src/main/java/com/dekk/card/domain/model/Product.java
+++ b/src/main/java/com/dekk/card/domain/model/Product.java
@@ -3,7 +3,7 @@ package com.dekk.card.domain.model;
 import com.dekk.card.application.command.ProductCreateCommand;
 import com.dekk.card.domain.exception.CardBusinessException;
 import com.dekk.card.domain.exception.CardErrorCode;
-import com.dekk.card.domain.model.enums.TargetGender;
+import com.dekk.card.domain.model.enums.ProductGender;
 import com.dekk.common.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
@@ -42,7 +42,7 @@ public class Product extends BaseTimeEntity {
     private String productUrl;
 
     @Enumerated(EnumType.STRING)
-    private TargetGender gender;
+    private ProductGender gender;
 
     @Column(name = "is_active", nullable = false)
     private boolean isActive;

--- a/src/main/java/com/dekk/card/domain/model/enums/ProductGender.java
+++ b/src/main/java/com/dekk/card/domain/model/enums/ProductGender.java
@@ -1,0 +1,28 @@
+package com.dekk.card.domain.model.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProductGender {
+    WOMEN("여성"),
+    MEN("남성"),
+    UNISEX("남녀공용"),
+    UNDEFINED("미정");
+
+    private final String description;
+
+    public static ProductGender musinsaParse(String value) {
+        if (value == null || value.isBlank()) {
+            return UNDEFINED;
+        }
+
+        return switch (value.trim().toUpperCase()) {
+            case "WOMEN" -> ProductGender.WOMEN;
+            case "MEN" -> ProductGender.MEN;
+            case "ALL" -> ProductGender.UNISEX;
+            default -> ProductGender.UNDEFINED;
+        };
+    }
+}

--- a/src/main/java/com/dekk/card/domain/repository/CardRepository.java
+++ b/src/main/java/com/dekk/card/domain/repository/CardRepository.java
@@ -1,10 +1,8 @@
 package com.dekk.card.domain.repository;
 
-import com.dekk.card.application.dto.query.RecommendCandidateQuery;
 import com.dekk.card.domain.model.Card;
 import com.dekk.card.domain.model.enums.CardStatus;
 import com.dekk.card.domain.model.enums.Platform;
-import com.dekk.card.domain.model.enums.TargetGender;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -18,6 +16,5 @@ public interface CardRepository {
     Page<Card> findCardsWithImageByStatus(CardStatus status, Pageable pageable);
     Page<Card> findCardsWithProductsByStatus(CardStatus status, Pageable pageable);
     List<Card> findAllByIdInWithProducts(List<Long> ids);
-    List<Card> findRecommendCandidates(RecommendCandidateQuery query);
     Optional<Card> findById(Long id);
 }

--- a/src/main/java/com/dekk/card/infrastructure/CardRepositoryImpl.java
+++ b/src/main/java/com/dekk/card/infrastructure/CardRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.dekk.card.infrastructure;
 
 import com.dekk.card.domain.model.Card;
-import com.dekk.card.application.dto.query.RecommendCandidateQuery;
 import com.dekk.card.domain.model.enums.CardStatus;
 import com.dekk.card.domain.model.enums.Platform;
 import com.dekk.card.domain.repository.CardRepository;
@@ -47,18 +46,6 @@ public class CardRepositoryImpl implements CardRepository {
     @Override
     public List<Card> findAllByIdInWithProducts(List<Long> ids) {
         return cardJpaRepository.findAllByIdInWithProducts(ids);
-    }
-
-    @Override
-    public List<Card> findRecommendCandidates(RecommendCandidateQuery query) {
-        return cardJpaRepository.findRecommendCandidates(
-                query.excludedCardIdsOrNull(),
-                query.genders(),
-                query.minHeight(),
-                query.maxHeight(),
-                query.minWeight(),
-                query.maxWeight()
-        );
     }
 
     @Override

--- a/src/main/java/com/dekk/card/infrastructure/jpa/CardJpaRepository.java
+++ b/src/main/java/com/dekk/card/infrastructure/jpa/CardJpaRepository.java
@@ -3,7 +3,6 @@ package com.dekk.card.infrastructure.jpa;
 import com.dekk.card.domain.model.Card;
 import com.dekk.card.domain.model.enums.CardStatus;
 import com.dekk.card.domain.model.enums.Platform;
-import com.dekk.card.domain.model.enums.TargetGender;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -25,23 +24,4 @@ public interface CardJpaRepository extends JpaRepository<Card, Long> {
 
     @Query("SELECT DISTINCT c FROM Card c JOIN FETCH c.cardImage LEFT JOIN FETCH c.cardProducts cp LEFT JOIN FETCH cp.product p LEFT JOIN FETCH p.productImage WHERE c.id IN :ids ORDER BY c.createdAt DESC")
     List<Card> findAllByIdInWithProducts(@Param("ids") List<Long> ids);
-
-    @Query("SELECT DISTINCT c FROM Card c " +
-            "JOIN FETCH c.cardImage " +
-            "JOIN c.cardProducts cp " +
-            "JOIN cp.product p " +
-            "WHERE c.status = 'APPROVED' " +
-            "AND p.isSimilar = false " +
-            "AND c.targetGender IN :genders " +
-            "AND (c.height IS NULL OR c.height BETWEEN :minHeight AND :maxHeight) " +
-            "AND (c.weight IS NULL OR c.weight BETWEEN :minWeight AND :maxWeight) " +
-            "AND (:excludedCardIds IS NULL OR c.id NOT IN :excludedCardIds)")
-    List<Card> findRecommendCandidates(
-            @Param("excludedCardIds") List<Long> excludedCardIds,
-            @Param("genders") List<TargetGender> genders,
-            @Param("minHeight") int minHeight,
-            @Param("maxHeight") int maxHeight,
-            @Param("minWeight") int minWeight,
-            @Param("maxWeight") int maxWeight
-    );
 }

--- a/src/main/java/com/dekk/crawl/infrastructure/parser/MusinsaCrawlDataParser.java
+++ b/src/main/java/com/dekk/crawl/infrastructure/parser/MusinsaCrawlDataParser.java
@@ -5,7 +5,7 @@ import com.dekk.card.application.command.CardImageCreateCommand;
 import com.dekk.card.application.command.ProductCreateCommand;
 import com.dekk.card.application.command.ProductImageCreateCommand;
 import com.dekk.card.domain.model.enums.Platform;
-import com.dekk.card.domain.model.enums.TargetGender;
+import com.dekk.card.domain.model.enums.ProductGender;
 import com.dekk.crawl.domain.parser.CrawlDataParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -58,7 +58,6 @@ public class MusinsaCrawlDataParser implements CrawlDataParser {
 
         CardImageCreateCommand cardImage = parseCardImage(snap);
         String tags = parseTags(snap);
-        TargetGender targetGender = parseGender(snap.path("model").path("gender"));
         Integer height = parseNullableInt(snap.path("model").path("height"));
         Integer weight = parseNullableInt(snap.path("model").path("weight"));
 
@@ -72,7 +71,6 @@ public class MusinsaCrawlDataParser implements CrawlDataParser {
                 tags,
                 originId,
                 Platform.MUSINSA,
-                targetGender,
                 height,
                 weight
         );
@@ -219,13 +217,13 @@ public class MusinsaCrawlDataParser implements CrawlDataParser {
         return products;
     }
 
-    private TargetGender parseGender(JsonNode genderNode) {
+    private ProductGender parseGender(JsonNode genderNode) {
         if (genderNode.isMissingNode() || genderNode.isNull()) {
             return null;
         }
 
         String value = genderNode.asText().toUpperCase();
-        return TargetGender.musinsaParse(value);
+        return ProductGender.musinsaParse(value);
     }
 
     private Integer parseNullableInt(JsonNode node) {

--- a/src/main/java/com/dekk/deck/application/CustomDeckQueryService.java
+++ b/src/main/java/com/dekk/deck/application/CustomDeckQueryService.java
@@ -1,24 +1,14 @@
 package com.dekk.deck.application;
 
-import com.dekk.card.application.CardQueryService;
-import com.dekk.card.application.dto.result.MemberCardResult;
 import com.dekk.deck.application.dto.result.CustomDeckResult;
-import com.dekk.deck.application.dto.result.MyDeckCardResult;
-import com.dekk.deck.domain.exception.DeckBusinessException;
-import com.dekk.deck.domain.exception.DeckErrorCode;
 import com.dekk.deck.domain.model.Deck;
-import com.dekk.deck.domain.model.DeckCard;
 import com.dekk.deck.domain.repository.DeckCardRepository;
 import com.dekk.deck.domain.repository.DeckRepository;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,7 +19,6 @@ public class CustomDeckQueryService {
 
     private final DeckRepository deckRepository;
     private final DeckCardRepository deckCardRepository;
-    private final CardQueryService cardQueryService;
 
     public List<CustomDeckResult> getMyCustomDecks(Long userId) {
         List<Deck> myCustomDecks = deckRepository.findAllByUserIdAndIsDefaultFalseOrderByCreatedAtDesc(userId);
@@ -51,53 +40,5 @@ public class CustomDeckQueryService {
                 cardCountMap.getOrDefault(deck.getId(), 0L)
             ))
             .toList();
-    }
-
-    public Page<MyDeckCardResult> getCustomDeckCards(Long userId, Long deckId, Pageable pageable) {
-        Deck deck = deckRepository.findByIdAndUserId(deckId, userId)
-            .orElseThrow(() -> new DeckBusinessException(DeckErrorCode.CUSTOM_DECK_NOT_FOUND));
-
-        Page<DeckCard> deckCards = deckCardRepository.findAllByDeckId(deck.getId(), pageable);
-
-        List<Long> cardIds = deckCards.getContent().stream()
-            .map(DeckCard::getCardId)
-            .toList();
-
-        List<MemberCardResult> cardResults = cardQueryService.getCardsByIds(cardIds);
-
-        Map<Long, MemberCardResult> cardMap = cardResults.stream()
-            .collect(Collectors.toMap(MemberCardResult::cardId, Function.identity()));
-
-        return deckCards.map(deckCard -> mapToMyDeckCardResult(deckCard, cardMap));
-    }
-
-    private MyDeckCardResult mapToMyDeckCardResult(DeckCard deckCard, Map<Long, MemberCardResult> cardMap) {
-        MemberCardResult cardInfo = cardMap.get(deckCard.getCardId());
-
-        if (cardInfo == null) {
-            return MyDeckCardResult.empty(deckCard.getCardId());
-        }
-
-        return convertToMyDeckCardResult(cardInfo);
-    }
-
-    private MyDeckCardResult convertToMyDeckCardResult(MemberCardResult cardInfo) {
-        List<MyDeckCardResult.ProductDetail> productDetails = cardInfo.products().stream()
-            .map(p -> new MyDeckCardResult.ProductDetail(
-                p.brand(),
-                p.productUrl(),
-                p.name(),
-                p.productImageUrl()
-            ))
-            .toList();
-
-        return new MyDeckCardResult(
-            cardInfo.cardId(),
-            cardInfo.cardImageUrl(),
-            cardInfo.height(),
-            cardInfo.weight(),
-            cardInfo.tags(),
-            productDetails
-        );
     }
 }

--- a/src/main/java/com/dekk/deck/application/DeckCommandService.java
+++ b/src/main/java/com/dekk/deck/application/DeckCommandService.java
@@ -1,0 +1,24 @@
+package com.dekk.deck.application;
+
+import com.dekk.deck.domain.model.Deck;
+import com.dekk.deck.domain.repository.DeckRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeckCommandService {
+
+    private final DeckRepository deckRepository;
+
+    public void createDefaultDeck(Long userId) {
+        if (deckRepository.findByUserIdAndIsDefaultTrue(userId).isPresent()) {
+            return;
+        }
+
+        Deck defaultDeck = Deck.createDefault(userId);
+        deckRepository.save(defaultDeck);
+    }
+}

--- a/src/main/java/com/dekk/deck/application/DeckQueryService.java
+++ b/src/main/java/com/dekk/deck/application/DeckQueryService.java
@@ -2,99 +2,73 @@ package com.dekk.deck.application;
 
 import com.dekk.card.application.CardQueryService;
 import com.dekk.card.application.dto.result.MemberCardResult;
-import com.dekk.deck.application.dto.result.DeckResult;
+import com.dekk.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.deck.domain.exception.DeckBusinessException;
 import com.dekk.deck.domain.exception.DeckErrorCode;
 import com.dekk.deck.domain.model.Deck;
 import com.dekk.deck.domain.model.DeckCard;
-import com.dekk.deck.domain.model.enums.DeckType;
 import com.dekk.deck.domain.repository.DeckCardRepository;
 import com.dekk.deck.domain.repository.DeckRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class DeckQueryService {
 
-    private static final int MAX_PREVIEW_CARD_COUNT = 3;
-
     private final DeckRepository deckRepository;
     private final DeckCardRepository deckCardRepository;
     private final CardQueryService cardQueryService;
 
-
-    public List<DeckResult> getDecks(Long userId) {
-        List<Deck> allDecks = getAllDecks(userId);
-        List<Long> deckIds = allDecks.stream().map(Deck::getId).toList();
-
-        Map<Long, Long> cardCountMap = deckCardRepository.countCardsByDeckIds(deckIds);
-
-        List<DeckCard> topDeckCards = deckCardRepository.findTopCardsByDeckIdsIn(deckIds, MAX_PREVIEW_CARD_COUNT);
-        Map<Long, List<Long>> topCardIdsPerDeck = extractTopCardIdsPerDeck(topDeckCards);
-
-        Map<Long, String> cardImageUrlMap = getCardImageUrlMap(topCardIdsPerDeck);
-
-        return allDecks.stream()
-            .map(deck -> mapToDeckResult(deck, cardCountMap, topCardIdsPerDeck, cardImageUrlMap))
-            .toList();
-    }
-
-    private List<Deck> getAllDecks(Long userId) {
+    public Page<MyDeckCardResult> getMyDefaultDeckCards(Long userId, Pageable pageable) {
         Deck defaultDeck = deckRepository.findByUserIdAndIsDefaultTrue(userId)
             .orElseThrow(() -> new DeckBusinessException(DeckErrorCode.DEFAULT_DECK_NOT_FOUND));
 
-        List<Deck> customDecks = deckRepository.findAllByUserIdAndIsDefaultFalseOrderByCreatedAtDesc(userId);
+        Page<DeckCard> deckCards = deckCardRepository.findAllByDeckId(defaultDeck.getId(), pageable);
 
-        return Stream.concat(Stream.of(defaultDeck), customDecks.stream()).toList();
-    }
-
-    private Map<Long, List<Long>> extractTopCardIdsPerDeck(List<DeckCard> topDeckCards) {
-        return topDeckCards.stream()
-            .collect(Collectors.groupingBy(
-                DeckCard::getDeckId,
-                Collectors.mapping(DeckCard::getCardId, Collectors.toList())
-            ));
-    }
-
-    private Map<Long, String> getCardImageUrlMap(Map<Long, List<Long>> topCardIdsPerDeck) {
-        List<Long> allTopCardIds = topCardIdsPerDeck.values().stream()
-            .flatMap(List::stream)
-            .distinct()
+        List<Long> cardIds = deckCards.getContent().stream()
+            .map(DeckCard::getCardId)
             .toList();
 
-        if (allTopCardIds.isEmpty()) {
-            return Map.of();
-        }
+        List<MemberCardResult> cardResults = cardQueryService.getCardsByIds(cardIds);
 
-        List<MemberCardResult> cardResults = cardQueryService.getCardsByIds(allTopCardIds);
-        return cardResults.stream()
-            .collect(Collectors.toMap(MemberCardResult::cardId, MemberCardResult::cardImageUrl));
-    }
+        Map<Long, MemberCardResult> cardMap = cardResults.stream()
+            .collect(Collectors.toMap(MemberCardResult::cardId, Function.identity()));
 
-    private DeckResult mapToDeckResult(Deck deck,
-                                       Map<Long, Long> cardCountMap,
-                                       Map<Long, List<Long>> topCardIdsPerDeck,
-                                       Map<Long, String> cardImageUrlMap) {
+        return deckCards.map(deckCard -> {
+            MemberCardResult cardInfo = cardMap.get(deckCard.getCardId());
 
-        List<String> previewUrls = topCardIdsPerDeck.getOrDefault(deck.getId(), List.of()).stream()
-            .map(cardId -> cardImageUrlMap.getOrDefault(cardId, ""))
-            .filter(url -> !url.isBlank())
-            .toList();
+            if (cardInfo == null) {
+                return MyDeckCardResult.empty(deckCard.getCardId());
+            }
 
-        return new DeckResult(
-            deck.getId(),
-            deck.getName(),
-            deck.isDefault() ? DeckType.DEFAULT : DeckType.CUSTOM,
-            cardCountMap.getOrDefault(deck.getId(), 0L),
-            previewUrls
-        );
+            List<MyDeckCardResult.ProductDetail> productDetails = cardInfo.products().stream()
+                .map(p -> new MyDeckCardResult.ProductDetail(
+                    p.brand(),
+                    p.productUrl(),
+                    p.name(),
+                    p.productImageUrl()
+                ))
+                .toList();
+
+            return new MyDeckCardResult(
+                cardInfo.cardId(),
+                cardInfo.cardImageUrl(),
+                cardInfo.height(),
+                cardInfo.weight(),
+                cardInfo.tags(),
+                productDetails
+            );
+        });
     }
 }

--- a/src/main/java/com/dekk/deck/domain/repository/DeckCardRepository.java
+++ b/src/main/java/com/dekk/deck/domain/repository/DeckCardRepository.java
@@ -24,8 +24,4 @@ public interface DeckCardRepository {
     Map<Long, Long> countCardsByDeckIds(List<Long> deckIds);
 
     long countByDeckId(Long deckId);
-
-    List<DeckCard> findAllByDeckIdIn(List<Long> deckIds);
-
-    List<DeckCard> findTopCardsByDeckIdsIn(List<Long> deckIds, int limit);
 }

--- a/src/main/java/com/dekk/deck/infrastructure/DeckCardRepositoryImpl.java
+++ b/src/main/java/com/dekk/deck/infrastructure/DeckCardRepositoryImpl.java
@@ -69,20 +69,4 @@ public class DeckCardRepositoryImpl implements DeckCardRepository {
     public long countByDeckId(Long deckId) {
         return deckCardJpaRepository.countByDeckId(deckId);
     }
-
-    @Override
-    public List<DeckCard> findAllByDeckIdIn(List<Long> deckIds) {
-        if (deckIds == null || deckIds.isEmpty()) {
-            return List.of();
-        }
-        return deckCardJpaRepository.findAllByDeckIdIn(deckIds);
-    }
-
-    @Override
-    public List<DeckCard> findTopCardsByDeckIdsIn(List<Long> deckIds, int limit) {
-        if (deckIds == null || deckIds.isEmpty()) {
-            return List.of();
-        }
-        return deckCardJpaRepository.findTopCardsByDeckIdsIn(deckIds, limit);
-    }
 }

--- a/src/main/java/com/dekk/deck/infrastructure/jpa/DeckCardJpaRepository.java
+++ b/src/main/java/com/dekk/deck/infrastructure/jpa/DeckCardJpaRepository.java
@@ -28,19 +28,4 @@ public interface DeckCardJpaRepository extends JpaRepository<DeckCard, Long> {
     List<DeckCardCountProjection> countCardsByDeckIds(@Param("deckIds") List<Long> deckIds);
 
     long countByDeckId(Long deckId);
-
-    List<DeckCard> findAllByDeckIdIn(List<Long> deckIds);
-
-    @Query(value = """
-        SELECT * FROM (
-            SELECT dc.*, ROW_NUMBER() OVER(PARTITION BY dc.deck_id ORDER BY dc.created_at DESC) as rn 
-            FROM deck_cards dc 
-            WHERE dc.deck_id IN (:deckIds) AND dc.deleted_at IS NULL
-        ) sub 
-        WHERE sub.rn <= :limit
-        """, nativeQuery = true)
-    List<DeckCard> findTopCardsByDeckIdsIn(
-        @Param("deckIds") List<Long> deckIds,
-        @Param("limit") int limit
-    );
 }

--- a/src/main/java/com/dekk/deck/presentation/controller/CustomDeckQueryApi.java
+++ b/src/main/java/com/dekk/deck/presentation/controller/CustomDeckQueryApi.java
@@ -1,19 +1,15 @@
 package com.dekk.deck.presentation.controller;
 
 import com.dekk.common.response.ApiResponse;
-import com.dekk.common.response.PageResponse;
 import com.dekk.deck.application.dto.result.CustomDeckResult;
-import com.dekk.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.security.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "커스텀 보관함 조회 API", description = "커스텀 보관함 목록 및 상태 조회 API")
@@ -25,15 +21,5 @@ public interface CustomDeckQueryApi {
     })
     ResponseEntity<ApiResponse<List<CustomDeckResult>>> getMyCustomDecks(
         @Parameter(hidden = true) CustomUserDetails userDetails
-    );
-
-    @Operation(summary = "커스텀 보관함 내부 카드 목록 조회", description = "특정 커스텀 보관함에 담긴 카드 목록을 페이징하여 조회합니다.")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20011)")
-    })
-    ResponseEntity<ApiResponse<PageResponse<MyDeckCardResult>>> getCustomDeckCards(
-        @Parameter(hidden = true) CustomUserDetails userDetails,
-        @Parameter(description = "조회할 커스텀 보관함 ID", in = ParameterIn.PATH) Long customDeckId,
-        Pageable pageable
     );
 }

--- a/src/main/java/com/dekk/deck/presentation/controller/CustomDeckQueryController.java
+++ b/src/main/java/com/dekk/deck/presentation/controller/CustomDeckQueryController.java
@@ -1,23 +1,17 @@
 package com.dekk.deck.presentation.controller;
 
 import com.dekk.common.response.ApiResponse;
-import com.dekk.common.response.PageResponse;
 import com.dekk.deck.application.CustomDeckQueryService;
 import com.dekk.deck.application.dto.result.CustomDeckResult;
-import com.dekk.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.deck.presentation.response.DeckResultCode;
 import com.dekk.security.oauth2.CustomUserDetails;
 
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -38,21 +32,6 @@ public class CustomDeckQueryController implements CustomDeckQueryApi {
         return ResponseEntity.ok(ApiResponse.of(
             DeckResultCode.CUSTOM_DECK_LIST_SUCCESS,
             result
-        ));
-    }
-
-    @Override
-    @GetMapping("/{customDeckId}/cards")
-    public ResponseEntity<ApiResponse<PageResponse<MyDeckCardResult>>> getCustomDeckCards(
-        @AuthenticationPrincipal CustomUserDetails userDetails,
-        @PathVariable("customDeckId") Long customDeckId,
-        @ParameterObject Pageable pageable
-    ) {
-        Page<MyDeckCardResult> result = customDeckQueryService.getCustomDeckCards(userDetails.getId(), customDeckId, pageable);
-
-        return ResponseEntity.ok(ApiResponse.of(
-            DeckResultCode.CUSTOM_DECK_CARD_LIST_SUCCESS,
-            PageResponse.from(result)
         ));
     }
 }

--- a/src/main/java/com/dekk/deck/presentation/controller/DeckCommandApi.java
+++ b/src/main/java/com/dekk/deck/presentation/controller/DeckCommandApi.java
@@ -1,0 +1,30 @@
+package com.dekk.deck.presentation.controller;
+
+import com.dekk.common.response.ApiResponse;
+import com.dekk.security.oauth2.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "보관함 관리 API", description = "보관함 및 보관함 내 카드 관리 API")
+public interface DeckCommandApi {
+
+    @Operation(summary = "기본 보관함에서 특정 카드 저장 취소 (Soft Delete)")
+    @ApiResponses(value = {
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SD20004: 보관함 내 카드 저장 취소 성공"),
+        @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "404",
+            description = "ED40401: 기본 보관함 미존재 / ED40402: 보관함 내 해당 카드 미존재",
+            content = @Content(schema = @Schema(implementation = ApiResponse.class))
+        )
+    })
+    ResponseEntity<ApiResponse<Void>> removeCardFromDefaultDeck(
+        @Parameter(hidden = true) CustomUserDetails userDetails,
+        @Parameter(description = "삭제할 카드 ID", in = ParameterIn.PATH) Long cardId
+    );
+}

--- a/src/main/java/com/dekk/deck/presentation/controller/DeckCommandController.java
+++ b/src/main/java/com/dekk/deck/presentation/controller/DeckCommandController.java
@@ -1,0 +1,34 @@
+package com.dekk.deck.presentation.controller;
+
+import com.dekk.common.response.ApiResponse;
+import com.dekk.deck.application.DeckCardCommandService;
+import com.dekk.deck.application.DeckCommandService;
+import com.dekk.deck.presentation.response.DeckResultCode;
+import com.dekk.security.oauth2.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/w/v1/decks")
+@RequiredArgsConstructor
+public class DeckCommandController implements DeckCommandApi {
+
+    private final DeckCommandService deckCommandService;
+    private final DeckCardCommandService deckCardCommandService;
+
+    @Override
+    @DeleteMapping("/default/cards/{cardId}")
+    public ResponseEntity<ApiResponse<Void>> removeCardFromDefaultDeck(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @PathVariable("cardId") Long cardId
+    ) {
+        deckCardCommandService.removeFromDefaultDeck(userDetails.getId(), cardId);
+        return ResponseEntity.ok(ApiResponse.from(DeckResultCode.DECK_CARD_DELETED_SUCCESS));
+    }
+}

--- a/src/main/java/com/dekk/deck/presentation/controller/DeckQueryApi.java
+++ b/src/main/java/com/dekk/deck/presentation/controller/DeckQueryApi.java
@@ -1,27 +1,21 @@
 package com.dekk.deck.presentation.controller;
 
 import com.dekk.common.response.ApiResponse;
-import com.dekk.deck.application.dto.result.DeckResult;
+import com.dekk.common.response.PageResponse;
+import com.dekk.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.security.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
-import java.util.List;
-
-@Tag(name = "통합 보관함 조회 API", description = "메인 홈 화면용 보관함 목록 통합 조회 API")
+@Tag(name = "보관함 조회 API", description = "내 보관함 정보 및 카드 목록 조회 API")
 public interface DeckQueryApi {
 
-    @Operation(summary = "내 보관함 통합 목록 조회", description = "기본 보관함과 커스텀 보관함을 통합 조회하며, 각 보관함의 최신 카드 썸네일(최대 3장)을 포함합니다.")
-    @ApiResponses(value = {
-        @io.swagger.v3.oas.annotations.responses.ApiResponse(
-            responseCode = "200",
-            description = "SD20012: 보관함 통합 목록 조회 성공"
-        )
-    })
-    ResponseEntity<ApiResponse<List<DeckResult>>> getDecks(
-        @Parameter(hidden = true) CustomUserDetails userDetails
+    @Operation(summary = "기본 보관함 카드 목록 페이징 조회")
+    ResponseEntity<ApiResponse<PageResponse<MyDeckCardResult>>> getMyDefaultDeckCards(
+        @Parameter(hidden = true) CustomUserDetails userDetails,
+        Pageable pageable
     );
 }

--- a/src/main/java/com/dekk/deck/presentation/controller/DeckQueryController.java
+++ b/src/main/java/com/dekk/deck/presentation/controller/DeckQueryController.java
@@ -1,18 +1,20 @@
 package com.dekk.deck.presentation.controller;
 
 import com.dekk.common.response.ApiResponse;
+import com.dekk.common.response.PageResponse;
 import com.dekk.deck.application.DeckQueryService;
-import com.dekk.deck.application.dto.result.DeckResult;
+import com.dekk.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.deck.presentation.response.DeckResultCode;
 import com.dekk.security.oauth2.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
-import java.util.List;
 
 @RestController
 @RequestMapping("/w/v1/decks")
@@ -22,15 +24,16 @@ public class DeckQueryController implements DeckQueryApi {
     private final DeckQueryService deckQueryService;
 
     @Override
-    @GetMapping
-    public ResponseEntity<ApiResponse<List<DeckResult>>> getDecks(
-        @AuthenticationPrincipal CustomUserDetails userDetails
+    @GetMapping("/default/cards")
+    public ResponseEntity<ApiResponse<PageResponse<MyDeckCardResult>>> getMyDefaultDeckCards(
+        @AuthenticationPrincipal CustomUserDetails userDetails,
+        @ParameterObject Pageable pageable
     ) {
-        List<DeckResult> result = deckQueryService.getDecks(userDetails.getId());
+        Page<MyDeckCardResult> pageResult = deckQueryService.getMyDefaultDeckCards(userDetails.getId(), pageable);
 
         return ResponseEntity.ok(ApiResponse.of(
-            DeckResultCode.DECK_LIST_SUCCESS,
-            result
+            DeckResultCode.DECK_CARD_LIST_SUCCESS,
+            PageResponse.from(pageResult)
         ));
     }
 }

--- a/src/main/java/com/dekk/deck/presentation/response/DeckResultCode.java
+++ b/src/main/java/com/dekk/deck/presentation/response/DeckResultCode.java
@@ -16,8 +16,6 @@ public enum DeckResultCode implements ResultCode {
     CUSTOM_DECK_LIST_SUCCESS(HttpStatus.OK, "SD20008", "커스텀 보관함 목록 조회 성공"),
     CUSTOM_DECK_CARD_SAVE_SUCCESS(HttpStatus.OK, "SD20009", "커스텀 보관함 카드 저장 성공"),
     CUSTOM_DECK_CARD_DELETE_SUCCESS(HttpStatus.OK, "SD20010", "커스텀 보관함 내 카드 삭제 성공"),
-    CUSTOM_DECK_CARD_LIST_SUCCESS(HttpStatus.OK, "SD20011", "커스텀 보관함 카드 목록 조회 성공"),
-    DECK_LIST_SUCCESS(HttpStatus.OK, "SD20012", "보관함 통합 목록 조회 성공"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/dekk/global/config/RedisConfig.java
+++ b/src/main/java/com/dekk/global/config/RedisConfig.java
@@ -1,0 +1,24 @@
+package com.dekk.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Profile("!test")
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        return redisTemplate;
+
+    }
+}

--- a/src/main/java/com/dekk/security/config/SecurityConfig.java
+++ b/src/main/java/com/dekk/security/config/SecurityConfig.java
@@ -4,7 +4,6 @@ import com.dekk.auth.application.CustomOAuth2UserService;
 import com.dekk.auth.jwt.filter.JwtAuthenticationFilter;
 import com.dekk.security.oauth2.handler.OAuth2FailureHandler;
 import com.dekk.security.oauth2.handler.OAuth2SuccessHandler;
-import com.dekk.security.oauth2.repository.InMemoryOAuth2AuthorizationRequestRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,8 +31,6 @@ public class SecurityConfig {
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
-
-    private final InMemoryOAuth2AuthorizationRequestRepository inMemoryOAuth2AuthorizationRequestRepository;
 
     @Value("${app.cors.allowed-origins}")
     private String allowedOrigins;
@@ -65,8 +62,6 @@ public class SecurityConfig {
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .authorizationEndpoint(authorization -> authorization
-                                .authorizationRequestRepository(inMemoryOAuth2AuthorizationRequestRepository))
                         .loginPage(loginPageUrl)
                         .userInfoEndpoint(userInfo -> userInfo
                                 .userService(customOAuth2UserService)
@@ -87,8 +82,7 @@ public class SecurityConfig {
 
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
-
-        configuration.setExposedHeaders(List.of("Set-Cookie"));
+        configuration.setExposedHeaders(List.of("Authorization"));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/dekk/security/oauth2/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/dekk/security/oauth2/handler/OAuth2SuccessHandler.java
@@ -1,7 +1,10 @@
 package com.dekk.security.oauth2.handler;
 
+
+import com.dekk.auth.domain.model.RefreshToken;
+import com.dekk.auth.domain.repository.RefreshTokenRepository;
 import com.dekk.auth.jwt.JwtTokenProvider;
-import com.dekk.auth.presentation.util.CookieUtil;
+import com.dekk.security.oauth2.CustomUserDetails;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -10,6 +13,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 
@@ -18,33 +22,34 @@ import java.io.IOException;
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final String redirectUri;
-
-    private final int accessTokenMaxAge;
-    private final int refreshTokenMaxAge;
 
     public OAuth2SuccessHandler(
             JwtTokenProvider jwtTokenProvider,
-            @Value("${app.oauth2.redirect-uri}") String redirectUri,
-            @Value("${jwt.access-token-validity-in-seconds}") int accessTokenMaxAge,
-            @Value("${jwt.refresh-token-validity-in-seconds}") int refreshTokenMaxAge) {
+            RefreshTokenRepository refreshTokenRepository,
+            @Value("${app.oauth2.redirect-uri}") String redirectUri) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.refreshTokenRepository = refreshTokenRepository;
         this.redirectUri = redirectUri;
-        this.accessTokenMaxAge = accessTokenMaxAge;
-        this.refreshTokenMaxAge = refreshTokenMaxAge;
     }
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         log.info("OAuth2 authentication successful. Generating JWT token...");
 
+        CustomUserDetails userDetails = (CustomUserDetails) authentication.getPrincipal();
+
         String accessToken = jwtTokenProvider.createAccessToken(authentication);
         String refreshToken = jwtTokenProvider.createRefreshToken(authentication);
 
-        log.info("Generated Access/Refresh Token (Hidden in Cookie)");
+        refreshTokenRepository.save(RefreshToken.create(userDetails.getId(), refreshToken));
 
-        CookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, accessToken, accessTokenMaxAge);
-        CookieUtil.addCookie(response, CookieUtil.REFRESH_TOKEN_NAME, refreshToken, refreshTokenMaxAge);
+        String targetUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("accessToken", accessToken)
+                .queryParam("refreshToken", refreshToken)
+                .build().toUriString();
 
-        getRedirectStrategy().sendRedirect(request, response, redirectUri);
+        getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 }

--- a/src/main/java/com/dekk/user/application/UserCommandService.java
+++ b/src/main/java/com/dekk/user/application/UserCommandService.java
@@ -1,6 +1,6 @@
 package com.dekk.user.application;
 
-import com.dekk.deck.application.DefaultDeckCommandService;
+import com.dekk.deck.application.DeckCommandService;
 import com.dekk.user.application.command.UserOnboardingCommand;
 import com.dekk.user.application.command.UserProfileUpdateCommand;
 import com.dekk.user.domain.exception.UserBusinessException;
@@ -19,7 +19,7 @@ public class UserCommandService {
 
     private final UserRepository userRepository;
     private final ProfileRepository profileRepository;
-    private final DefaultDeckCommandService deckCommandService;
+    private final DeckCommandService deckCommandService;
 
     public void onboardUser(Long userId, UserOnboardingCommand command) {
         User user = getUser(userId);
@@ -54,11 +54,11 @@ public class UserCommandService {
 
     private User getUser(Long userId) {
         return userRepository.findById(userId)
-            .orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
     }
 
     private User getUserWithProfile(Long userId) {
         return userRepository.findWithProfileById(userId)
-            .orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
+                .orElseThrow(() -> new UserBusinessException(UserErrorCode.USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈
[DK-203](https://potenup-final.atlassian.net/browse/DK-203?atlOrigin=eyJpIjoiOWY0YmQ1NTY1ZDQyNDkyYmE3N2M5MDY2OGNlNTgxNTMiLCJwIjoiaiJ9)
[DK-205](https://potenup-final.atlassian.net/browse/DK-205?atlOrigin=eyJpIjoiNzA2MmQyOTRlYTZmNGIyNzk1Zjk5Njc2ZGRlMTUwYmYiLCJwIjoiaiJ9)

## 📝작업 내용
JWT의 무상태성(Stateless)을 유지하면서 보안성을 강화하기 위해 Redis를 도입하고, Refresh Token의 생명주기를 서버사이드에서 관리하도록 구현했습니다.

- Redis 인프라 설정: RedisConfig를 통해 StringRedisSerializer를 사용하는 RedisTemplate 빈 등록

> **Refresh Token 상태 관리**

- 로그인 성공 시 RefreshToken을 Redis에 저장하도록 OAuth2SuccessHandler 수정

- 재발급 시 Redis에 저장된 값과 대조하여 RTR(Refresh Token Rotation) 로직 적용

- 로그아웃 시 Redis에서 해당 유저의 RT를 즉시 삭제

>**성능 최적화**

- JwtAuthenticationFilter에서 매 요청마다 Redis를 조회하지 않도록 설계하여 Stateless 특성 보장

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
PR이 머지된 직후에 AWS ElastiCache 세팅하는 yml 작성 공유하겠습니다 ! 

[DK-203]: https://potenup-final.atlassian.net/browse/DK-203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DK-205]: https://potenup-final.atlassian.net/browse/DK-205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ