### PR TITLE
[FIX] 카드 조회 N+1 이슈 수정

### DIFF
--- a/src/main/java/com/dekk/card/infrastructure/CardRepositoryImpl.java
+++ b/src/main/java/com/dekk/card/infrastructure/CardRepositoryImpl.java
@@ -62,7 +62,6 @@ public class CardRepositoryImpl implements CardRepository {
     @Override
     public List<Card> findRecommendCandidates(RecommendCandidateQuery query) {
         return cardJpaRepository.findRecommendCandidates(
-                query.excludedCardIdsOrNull(),
                 query.genders(),
                 query.minHeight(),
                 query.maxHeight(),

--- a/src/main/java/com/dekk/card/infrastructure/jpa/CardJpaRepository.java
+++ b/src/main/java/com/dekk/card/infrastructure/jpa/CardJpaRepository.java
@@ -33,16 +33,14 @@ public interface CardJpaRepository extends JpaRepository<Card, Long> {
 
     @Query("SELECT DISTINCT c FROM Card c " +
             "JOIN FETCH c.cardImage " +
-            "LEFT JOIN FETCH c.cardProducts cp " +
+            "JOIN FETCH c.cardProducts cp " +
             "LEFT JOIN FETCH cp.product p " +
             "LEFT JOIN FETCH p.productImage " +
             "WHERE c.status = 'APPROVED' " +
             "AND c.targetGender IN :genders " +
             "AND (c.height IS NULL OR c.height BETWEEN :minHeight AND :maxHeight) " +
-            "AND (c.weight IS NULL OR c.weight BETWEEN :minWeight AND :maxWeight) " +
-            "AND (:excludedCardIds IS NULL OR c.id NOT IN :excludedCardIds)")
+            "AND (c.weight IS NULL OR c.weight BETWEEN :minWeight AND :maxWeight)")
     List<Card> findRecommendCandidates(
-            @Param("excludedCardIds") List<Long> excludedCardIds,
             @Param("genders") List<TargetGender> genders,
             @Param("minHeight") int minHeight,
             @Param("maxHeight") int maxHeight,


### PR DESCRIPTION
## #️⃣연관된 이슈
[지라 티켓 번호](https://potenup-final.atlassian.net/browse/DK-295)
[연관된 이슈](https://potenup-final.atlassian.net/browse/DK-254)

## 📝작업 내용
- CardJpaRepository에서 findCradsWithProductsByStatus가 Card만 가져오는 이슈 수정
- pagenation과 동시에 모든 데이터를 가져오는데 한계가 있어서 id 목록을 조회한 뒤 이 id에 해당하는 Card 목록을 조회하도록 바꿨습니다
- findRecommendCadidates에서 join을 left joihn fetch로 변경했습니다. 만약 Product, ProductImage가 없는 card는 조회에서 제외되어야 한다면 join fetch 로 수정해야 합니다!
- 아래 요구사항에 의해 product의 isSimilar = false 조건이 있었는데 상품에 gender가 제외되어 조회에서 제외 시켰습니다 혹시 수정되어야 한다면 말씀해 주세요!
<img width="1464" height="175" alt="image" src="https://github.com/user-attachments/assets/bb5784be-67a5-4320-9b58-261af542d59b" />
