### PR TITLE
[REFACTOR] 커스텀 보관함 상세 조회 API 페이징 제거 및 List 반환 최적화 (#DK-291)

### DIFF
--- a/src/main/java/com/dekk/deck/application/CustomDeckQueryService.java
+++ b/src/main/java/com/dekk/deck/application/CustomDeckQueryService.java
@@ -17,8 +17,6 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,13 +51,17 @@ public class CustomDeckQueryService {
             .toList();
     }
 
-    public Page<MyDeckCardResult> getCustomDeckCards(Long userId, Long deckId, Pageable pageable) {
+    public List<MyDeckCardResult> getCustomDeckCards(Long userId, Long deckId) {
         Deck deck = deckRepository.findByIdAndUserId(deckId, userId)
             .orElseThrow(() -> new DeckBusinessException(DeckErrorCode.CUSTOM_DECK_NOT_FOUND));
 
-        Page<DeckCard> deckCards = deckCardRepository.findAllByDeckId(deck.getId(), pageable);
+        List<DeckCard> deckCards = deckCardRepository.findAllByDeckIdOrderByCreatedAtDesc(deck.getId());
 
-        List<Long> cardIds = deckCards.getContent().stream()
+        if (deckCards.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> cardIds = deckCards.stream()
             .map(DeckCard::getCardId)
             .toList();
 
@@ -68,7 +70,9 @@ public class CustomDeckQueryService {
         Map<Long, MemberCardResult> cardMap = cardResults.stream()
             .collect(Collectors.toMap(MemberCardResult::cardId, Function.identity()));
 
-        return deckCards.map(deckCard -> mapToMyDeckCardResult(deckCard, cardMap));
+        return deckCards.stream()
+            .map(deckCard -> mapToMyDeckCardResult(deckCard, cardMap))
+            .toList();
     }
 
     private MyDeckCardResult mapToMyDeckCardResult(DeckCard deckCard, Map<Long, MemberCardResult> cardMap) {

--- a/src/main/java/com/dekk/deck/domain/repository/DeckCardRepository.java
+++ b/src/main/java/com/dekk/deck/domain/repository/DeckCardRepository.java
@@ -28,4 +28,6 @@ public interface DeckCardRepository {
     List<DeckCard> findAllByDeckIdIn(List<Long> deckIds);
 
     List<DeckCard> findTopCardsByDeckIdsIn(List<Long> deckIds, int limit);
+
+    List<DeckCard> findAllByDeckIdOrderByCreatedAtDesc(Long deckId);
 }

--- a/src/main/java/com/dekk/deck/infrastructure/DeckCardRepositoryImpl.java
+++ b/src/main/java/com/dekk/deck/infrastructure/DeckCardRepositoryImpl.java
@@ -85,4 +85,9 @@ public class DeckCardRepositoryImpl implements DeckCardRepository {
         }
         return deckCardJpaRepository.findTopCardsByDeckIdsIn(deckIds, limit);
     }
+
+    @Override
+    public List<DeckCard> findAllByDeckIdOrderByCreatedAtDesc(Long deckId) {
+        return deckCardJpaRepository.findAllByDeckIdOrderByCreatedAtDesc(deckId);
+    }
 }

--- a/src/main/java/com/dekk/deck/infrastructure/jpa/DeckCardJpaRepository.java
+++ b/src/main/java/com/dekk/deck/infrastructure/jpa/DeckCardJpaRepository.java
@@ -43,4 +43,6 @@ public interface DeckCardJpaRepository extends JpaRepository<DeckCard, Long> {
         @Param("deckIds") List<Long> deckIds,
         @Param("limit") int limit
     );
+
+    List<DeckCard> findAllByDeckIdOrderByCreatedAtDesc(Long deckId);
 }

--- a/src/main/java/com/dekk/deck/presentation/controller/CustomDeckQueryApi.java
+++ b/src/main/java/com/dekk/deck/presentation/controller/CustomDeckQueryApi.java
@@ -1,7 +1,6 @@
 package com.dekk.deck.presentation.controller;
 
 import com.dekk.common.response.ApiResponse;
-import com.dekk.common.response.PageResponse;
 import com.dekk.deck.application.dto.result.CustomDeckResult;
 import com.dekk.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.security.oauth2.CustomUserDetails;
@@ -13,7 +12,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "커스텀 보관함 조회 API", description = "커스텀 보관함 목록 및 상태 조회 API")
@@ -27,13 +25,12 @@ public interface CustomDeckQueryApi {
         @Parameter(hidden = true) CustomUserDetails userDetails
     );
 
-    @Operation(summary = "커스텀 보관함 내부 카드 목록 조회", description = "특정 커스텀 보관함에 담긴 카드 목록을 페이징하여 조회합니다.")
+    @Operation(summary = "커스텀 보관함 내부 카드 목록 조회", description = "특정 커스텀 보관함에 담긴 카드 목록을 최신순으로 전체 조회합니다. (최대 50장)")
     @ApiResponses(value = {
         @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20011)")
     })
-    ResponseEntity<ApiResponse<PageResponse<MyDeckCardResult>>> getCustomDeckCards(
+    ResponseEntity<ApiResponse<List<MyDeckCardResult>>> getCustomDeckCards(
         @Parameter(hidden = true) CustomUserDetails userDetails,
-        @Parameter(description = "조회할 커스텀 보관함 ID", in = ParameterIn.PATH) Long customDeckId,
-        Pageable pageable
+        @Parameter(description = "조회할 커스텀 보관함 ID", in = ParameterIn.PATH) Long customDeckId
     );
 }

--- a/src/main/java/com/dekk/deck/presentation/controller/CustomDeckQueryController.java
+++ b/src/main/java/com/dekk/deck/presentation/controller/CustomDeckQueryController.java
@@ -1,7 +1,6 @@
 package com.dekk.deck.presentation.controller;
 
 import com.dekk.common.response.ApiResponse;
-import com.dekk.common.response.PageResponse;
 import com.dekk.deck.application.CustomDeckQueryService;
 import com.dekk.deck.application.dto.result.CustomDeckResult;
 import com.dekk.deck.application.dto.result.MyDeckCardResult;
@@ -11,9 +10,6 @@ import com.dekk.security.oauth2.CustomUserDetails;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -43,16 +39,15 @@ public class CustomDeckQueryController implements CustomDeckQueryApi {
 
     @Override
     @GetMapping("/{customDeckId}/cards")
-    public ResponseEntity<ApiResponse<PageResponse<MyDeckCardResult>>> getCustomDeckCards(
+    public ResponseEntity<ApiResponse<List<MyDeckCardResult>>> getCustomDeckCards(
         @AuthenticationPrincipal CustomUserDetails userDetails,
-        @PathVariable("customDeckId") Long customDeckId,
-        @ParameterObject Pageable pageable
+        @PathVariable("customDeckId") Long customDeckId
     ) {
-        Page<MyDeckCardResult> result = customDeckQueryService.getCustomDeckCards(userDetails.getId(), customDeckId, pageable);
+        List<MyDeckCardResult> result = customDeckQueryService.getCustomDeckCards(userDetails.getId(), customDeckId);
 
         return ResponseEntity.ok(ApiResponse.of(
             DeckResultCode.CUSTOM_DECK_CARD_LIST_SUCCESS,
-            PageResponse.from(result)
+            result
         ));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> # [DK-291](https://potenup-final.atlassian.net/browse/DK-291)

## 📝작업 내용

> 기존 커스텀 보관함 내부 상세 조회 API(`getCustomDeckCards`)의 불필요한 페이징(Pageable)을 걷어내고 순수 List 반환 구조로 최적화했습니다.

- **작업 배경**: 커스텀 보관함은 기획상 '최대 50장'의 카드만 저장할 수 있는 제약 조건이 있습니다. 최대 50건의 고정된 데이터를 위해 페이징을 유지하는 것은 불필요한 `COUNT` 쿼리 오버헤드를 발생시키며 연동 복잡도를 높이므로, 순수 List로 한 번에 반환하도록 개선했습니다.
- **Repository 계층**: 전체 카드를 최신순으로 가져오는 `findAllByDeckIdOrderByCreatedAtDesc` (List 반환) 메서드를 추가했습니다.
- **Service 계층**: `Pageable` 파라미터 의존성을 제거하고, 데이터가 없을 경우 `List.of()`로 빠른 반환(Early Return)을 처리하여 불필요한 쿼리를 방지했습니다.
- **Presentation 계층 (Controller/API)**: 반환 응답값을 포장하던 `PageResponse`를 걷어내고 순수 `List<MyDeckCardResult>`로 반환하도록 변경했으며, Swagger 명세를 업데이트했습니다.


### 스크린샷 (선택)
<img width="491" height="683" alt="스크린샷 2026-03-10 오전 10 33 08" src="https://github.com/user-attachments/assets/4d60fe7e-5119-4dba-a0a5-5fd5c4662fec" />

## 💬리뷰 요구사항(선택)

> 프론트엔드 API 연동 시 응답 스펙 변화에 주의해 주세요! 📢

- 이번 페이징 제거 리팩토링은 50장 제한이 있는 **`CustomDeck`(커스텀 보관함) 도메인에만 반영**되었습니다. 카드 수 제한이 없는 `DefaultDeck`(기본 보관함)은 기존과 동일하게 페이징 처리되니 연동 시 참고 부탁드립니다.
- 불필요한 DB 쿼리(COUNT) 오버헤드를 줄이고 연동을 단순화하기 위한 최적화 작업입니다. 코드를 보시고 더 좋은 개선 방향이 있다면 편하게 리뷰 남겨주세요!

[DK-291]: https://potenup-final.atlassian.net/browse/DK-291?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ