### PR TITLE
[CHORE] S3 저장되는 배포 파일 버전 관리 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,8 +39,12 @@ jobs:
 
       - name: 6. S3에 빌드 결과물 업로드
         run: |
+          DATE=$(date +'%Y%m%d')
+          SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+          VERSION="${DATE}-${SHORT_SHA}"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
           zip -r deploy.zip appspec.yml scripts build/libs/*.jar
-          aws s3 cp deploy.zip s3://dekk-deploy-bucket/deploy.zip
+          aws s3 cp deploy.zip s3://dekk-deploy-bucket/deploy-$VERSION.zip
 
       - name: 7. CodeDeploy 실행
         run: |
@@ -48,4 +52,4 @@ jobs:
             --application-name dekk-api-server \
             --deployment-config-name CodeDeployDefault.AllAtOnce \
             --deployment-group-name dekk-was-deploy-group \
-            --s3-location bucket=dekk-deploy-bucket,bundleType=zip,key=deploy.zip
+            --s3-location bucket=dekk-deploy-bucket,bundleType=zip,key=deploy-${{ env.VERSION }}.zip


### PR DESCRIPTION
## #️⃣연관된 이슈

[DK-305](https://potenup-final.atlassian.net/browse/DK-305)

## 📝작업 내용
```
deploy-20260312-f1a2b3c.zip 
```
- s3에 저장되는 파일명을 Github Short SHA와 날짜를 조합하여 버전 관리를 진행할 수 있게 하였습니다.
- Github Short SHA는 배포된 커밋이 무엇인지 추적에 용이합니다.
- 날짜는 S3의 정렬에 도움을 줍니다.

### 날짜 + shortSHA 파일명 방식을 선택한 이유
여러 가지 방식 (날짜만, sha만, 릴리즈 태그로)이 있었지만, 아래와 같은 이유로

  - Git 히스토리와 1:1 매핑 → 어떤 코드가 배포됐는지 즉시 추적 가능
  - GitHub Actions, GitLab CI, Jenkins 모두 기본 제공
  - 날짜는 같은 날 여러 번 배포 시 충돌 가능성 있음
  - 태그(v1.0.0)는 모든 배포마다 태그를 달아야 해서 번거로움

날짜와 sha를 혼합해서 사용하는 것이 가장 이상적이라고 판단하였습니다.

[DK-305]: https://potenup-final.atlassian.net/browse/DK-305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ