### PR TITLE
[PERF] 통합 덱 조회 쿼리 성능 최적화 및 실행 계획 개선(#DK-412)

### DIFF
--- a/src/main/java/com/dekk/deck/infrastructure/jpa/DeckJpaRepository.java
+++ b/src/main/java/com/dekk/deck/infrastructure/jpa/DeckJpaRepository.java
@@ -11,23 +11,20 @@ import org.springframework.data.repository.query.Param;
 public interface DeckJpaRepository extends JpaRepository<Deck, Long> {
 
     @Query("SELECT d FROM Deck d JOIN DeckMember dm ON d.id = dm.deckId "
-            + "WHERE dm.userId = :userId AND d.deckType = :deckType "
-            + "AND dm.deletedAt IS NULL AND d.deletedAt IS NULL")
+            + "WHERE dm.userId = :userId AND d.deckType = :deckType")
     Optional<Deck> findByUserIdAndDeckType(@Param("userId") Long userId, @Param("deckType") DeckType deckType);
 
-    @Query("SELECT d FROM Deck d JOIN DeckMember dm ON d.id = dm.deckId " + "WHERE d.id = :id AND dm.userId = :userId "
-            + "AND dm.deletedAt IS NULL AND d.deletedAt IS NULL")
+    @Query("SELECT d FROM Deck d JOIN DeckMember dm ON d.id = dm.deckId " + "WHERE d.id = :id AND dm.userId = :userId")
     Optional<Deck> findByIdAndMemberUserId(@Param("id") Long id, @Param("userId") Long userId);
 
     @Query("SELECT d FROM Deck d JOIN DeckMember dm ON d.id = dm.deckId "
             + "WHERE dm.userId = :userId AND d.deckType != :deckType "
-            + "AND dm.deletedAt IS NULL AND d.deletedAt IS NULL "
             + "ORDER BY d.createdAt DESC")
     List<Deck> findByUserIdAndDeckTypeNotOrderByCreatedAtDesc(
             @Param("userId") Long userId, @Param("deckType") DeckType deckType);
 
-    @Query("SELECT d FROM Deck d JOIN DeckMember dm ON d.id = dm.deckId " + "WHERE dm.userId = :userId "
-            + "AND dm.deletedAt IS NULL AND d.deletedAt IS NULL "
+    @Query("SELECT d FROM Deck d JOIN DeckMember dm ON d.id = dm.deckId "
+            + "WHERE dm.userId = :userId "
             + "ORDER BY CASE WHEN d.deckType = :defaultType THEN 0 ELSE 1 END, d.createdAt DESC")
     List<Deck> findAllByUserIdOrderByTypeAndCreatedAtDesc(
             @Param("userId") Long userId, @Param("defaultType") DeckType defaultType);

--- a/src/main/resources/db/migration/V9__optimize_deck_indexes.sql
+++ b/src/main/resources/db/migration/V9__optimize_deck_indexes.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_decks_user_id;
+DROP INDEX IF EXISTS idx_deck_cards_deck_id;
+DROP INDEX IF EXISTS idx_deck_members_deck_id;
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> # [DK-412](https://potenup-final.atlassian.net/browse/DK-412)

## 📝 작업 내용

> 이번 PR은 메인 홈 화면에서 호출되는 통합 덱 조회 API(`/w/v1/decks`)의 DB 실행 계획(Execution Plan)을 최적화하여, 트래픽 폭주 상황에서도 커넥션 풀 고갈 없이 안정적인 성능을 보장하기 위한 튜닝 작업입니다.

* **Hibernate `@Filter` 런타임 위임 및 JPQL 최적화**
  * `DeckJpaRepository`의 조회 쿼리 내 중복 기재되었던 `deletedAt IS NULL` 조건을 모두 제거했습니다.
  * 글로벌하게 적용된 `@Filter(name = "deletedFilter")`가 런타임에 자동으로 조건을 덧붙이므로, 쿼리 복잡도를 줄이고 가독성을 높였습니다.
* **불필요한 인덱스 제거 (V9 마이그레이션 스크립트 추가)**
  * V7 마이그레이션에서 생성되었으나 실제 쿼리 패턴과 맞지 않아 옵티마이저의 혼선만 유발하던 미사용 인덱스 3종(`decks`, `deck_members`, `deck_cards`)을 DROP 처리하는 `V9` 스크립트를 추가했습니다. 
  * 이를 통해 무의미한 인덱스 업데이트로 인한 쓰기(Write) 오버헤드도 함께 제거되었습니다.
* **실행 계획 개선 (`Nested Loop` ➔ `Hash Join`) 및 연산 비용 80% 감소**
  * 옵티마이저가 엉뚱한 인덱스를 타며 수백 번 평가하던 비효율적인 `Nested Loop` 연산을 끊어내고, 가장 효율적인 `Hash Join` 노드를 선택하도록 유도했습니다.
  * 결과적으로 쿼리의 Total Cost가 **18.88에서 2.27로 약 80% 이상 대폭 감소**했습니다.

### 스크린샷 (선택)

> **[최적화 적용 후 EXPLAIN ANALYZE 결과]**
<pre>
Sort Key = ["(CASE WHEN ((d.deck_type)::text = 'DEFAULT'::text) THEN 0 ELSE 1 END)","d.created_at DESC"];
  HASH_JOIN (hash join) (Cost: 2.25..1.12)
    Inner Unique = true;
    Hash Cond = (dm.deck_id = d.id);
    SEQ_SCAN (Seq Scan) table: deck_members; (Cost: 1.09..0.0)
    TRANSFORM (Hash) (Cost: 1.11..1.11)
      SEQ_SCAN (Seq Scan) table: decks; (Cost: 1.11..0.0) Filter = (user_id = 1);
</pre>
*(데이터가 수만 건으로 늘어날 경우, 테이블 스캔 대신 기존의 유효한 복합 인덱스 `uk_deck_member_user_deck` 를 탑니다)*

## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

* **V9 마이그레이션 확인:** 새로 추가된 `V9__optimize_deck_indexes.sql` 파일에 불필요한 트랜잭션 구문(ex. `VACUUM ANALYZE`)이 완전히 제거되고 순수 `DROP INDEX` 구문만 남아있는지 확인 부탁드립니다. (해당 스크립트는 운영 환경 배포 시 다운타임 없이 안전하게 적용됩니다.)
* **아키텍처/성능 컨벤션 전파:** 이번 튜닝 건을 참고하여, 추후 다른 도메인에서도 `ROWS=0` 상태의 가짜 플랜에 속아 무분별하게 단일 인덱스를 추가하는 것을 지양해주시기 바랍니다. 필요한 경우 복합 인덱스를 구성하거나 `Hash Join`을 유도하는 방향으로 팀 쿼리 튜닝 기준을 삼았으면 합니다.

[DK-412]: https://potenup-final.atlassian.net/browse/DK-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ