### PR TITLE
[FEAT] 로그아웃시 refreshToken 삭제

### DIFF
--- a/src/main/java/com/dekk/auth/presentation/controller/AuthApi.java
+++ b/src/main/java/com/dekk/auth/presentation/controller/AuthApi.java
@@ -1,12 +1,14 @@
 package com.dekk.auth.presentation.controller;
 
 import com.dekk.common.response.ApiResponse;
+import com.dekk.security.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 
 @Tag(name = "인증 API", description = "토큰 재발급 및 로그아웃 API (HttpOnly 쿠키 기반)")
@@ -33,5 +35,7 @@ public interface AuthApi {
                         responseCode = "200",
                         description = "로그아웃 성공 (SA20002)")
             })
-    ResponseEntity<ApiResponse<Void>> logout(@Parameter(hidden = true) HttpServletResponse response);
+    ResponseEntity<ApiResponse<Void>> logout(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(hidden = true) HttpServletResponse response);
 }

--- a/src/main/java/com/dekk/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/dekk/auth/presentation/controller/AuthController.java
@@ -6,9 +6,11 @@ import com.dekk.auth.application.dto.result.TokenRefreshResult;
 import com.dekk.auth.presentation.response.AuthResultCode;
 import com.dekk.auth.presentation.util.CookieUtil;
 import com.dekk.common.response.ApiResponse;
+import com.dekk.security.oauth2.CustomUserDetails;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,8 +51,10 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthenticationPrincipal CustomUserDetails userDetails, HttpServletResponse response) {
 
+        authCommandService.logout(userDetails.getId());
         cookieUtil.deleteCookie(response, CookieUtil.ACCESS_TOKEN_NAME);
         cookieUtil.deleteCookie(response, CookieUtil.REFRESH_TOKEN_NAME);
 


### PR DESCRIPTION
## #️⃣연관된 이슈
[DK-415](https://potenup-final.atlassian.net/browse/DK-415?atlOrigin=eyJpIjoiNDYyOWZhYWEwMGEzNDYzZmIwZTA0YjQ5NjU4NTE0ZGUiLCJwIjoiaiJ9)


## 📝작업 내용
- 로그아웃시 RefreshToken이 삭제되는 로직이 누락되어 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요


[DK-415]: https://potenup-final.atlassian.net/browse/DK-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ