### PR TITLE
[FEAT] 카드 생성 비즈니스 로직 & 서비스 레이어 구현

### DIFF
--- a/src/main/java/com/dekk/app/card/application/CardCommandService.java
+++ b/src/main/java/com/dekk/app/card/application/CardCommandService.java
@@ -2,15 +2,19 @@ package com.dekk.app.card.application;
 
 import com.dekk.app.card.application.dto.command.AssignCategoriesCommand;
 import com.dekk.app.card.application.dto.command.RequestDeleteCardCommand;
+import com.dekk.app.card.application.dto.command.UserCardCreateCommand;
 import com.dekk.app.card.domain.exception.CardBusinessException;
 import com.dekk.app.card.domain.exception.CardErrorCode;
 import com.dekk.app.card.domain.model.Card;
 import com.dekk.app.card.domain.model.CardCategory;
 import com.dekk.app.card.domain.model.CardDeleteReason;
+import com.dekk.app.card.domain.model.enums.TargetGender;
 import com.dekk.app.card.domain.repository.CardCategoryRepository;
 import com.dekk.app.card.domain.repository.CardDeleteReasonRepository;
 import com.dekk.app.card.domain.repository.CardRepository;
 import com.dekk.app.category.application.CategoryQueryService;
+import com.dekk.app.user.application.UserQueryService;
+import com.dekk.app.user.application.dto.result.UserInfoResult;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -27,6 +31,24 @@ public class CardCommandService {
     private final CardCategoryRepository cardCategoryRepository;
     private final CardDeleteReasonRepository cardDeleteReasonRepository;
     private final CategoryQueryService categoryQueryService;
+    private final UserQueryService userQueryService;
+
+    public Long createCardByUser(UserCardCreateCommand command) {
+        UserInfoResult userInfo = userQueryService.getMyInfo(command.userId());
+        TargetGender targetGender = TargetGender.fromGender(userInfo.gender());
+
+        Card card = Card.createByUser(
+                command.userId(),
+                command.cardImage(),
+                command.productCreateCommands(),
+                command.tags(),
+                userInfo.height(),
+                userInfo.weight(),
+                targetGender);
+
+        Card savedCard = cardRepository.save(card);
+        return savedCard.getId();
+    }
 
     public void approveCard(Long cardId) {
         Card card = findCardOrThrow(cardId);

--- a/src/main/java/com/dekk/app/card/application/dto/command/UserCardCreateCommand.java
+++ b/src/main/java/com/dekk/app/card/application/dto/command/UserCardCreateCommand.java
@@ -1,0 +1,6 @@
+package com.dekk.app.card.application.dto.command;
+
+import java.util.List;
+
+public record UserCardCreateCommand(
+        Long userId, CardImageCreateCommand cardImage, List<ProductCreateCommand> productCreateCommands, String tags) {}

--- a/src/main/java/com/dekk/app/card/domain/exception/CardErrorCode.java
+++ b/src/main/java/com/dekk/app/card/domain/exception/CardErrorCode.java
@@ -18,6 +18,7 @@ public enum CardErrorCode implements ErrorCode {
     CATEGORY_ID_IS_REQUIRED(HttpStatus.BAD_REQUEST, "EC40012", "카테고리 ID는 필수값입니다."),
     CARD_DELETE_REASON_IS_REQUIRED(HttpStatus.BAD_REQUEST, "EC40013", "카드 삭제 사유는 필수값입니다."),
     ADMIN_ID_IS_REQUIRED(HttpStatus.BAD_REQUEST, "EC40014", "관리자 ID는 필수값입니다."),
+    CARD_USER_ID_IS_REQUIRED_TO_CREATE(HttpStatus.BAD_REQUEST, "EC40015", "사용자 ID는 필수 값입니다."),
 
     CARD_NOT_FOUND(HttpStatus.NOT_FOUND, "EC40401", "카드를 찾을 수 없습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "EC40402", "존재하지 않는 카테고리가 포함되어 있습니다."),

--- a/src/main/java/com/dekk/app/card/domain/model/Card.java
+++ b/src/main/java/com/dekk/app/card/domain/model/Card.java
@@ -1,6 +1,8 @@
 package com.dekk.app.card.domain.model;
 
 import com.dekk.app.card.application.dto.command.CardCreateCommand;
+import com.dekk.app.card.application.dto.command.CardImageCreateCommand;
+import com.dekk.app.card.application.dto.command.ProductCreateCommand;
 import com.dekk.app.card.domain.exception.CardBusinessException;
 import com.dekk.app.card.domain.exception.CardErrorCode;
 import com.dekk.app.card.domain.model.enums.CardStatus;
@@ -43,7 +45,10 @@ public class Card extends BaseTimeEntity {
     @Column(name = "tags")
     private String tags;
 
-    @Column(name = "origin_id", nullable = false, updatable = false)
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "origin_id", updatable = false)
     private String originId;
 
     @Enumerated(EnumType.STRING)
@@ -51,7 +56,7 @@ public class Card extends BaseTimeEntity {
     private CardStatus status;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column
     private Platform platform;
 
     @Enumerated(EnumType.STRING)
@@ -65,6 +70,7 @@ public class Card extends BaseTimeEntity {
     private Card(
             CardImage cardImage,
             String tags,
+            Long userId,
             String originId,
             Platform platform,
             TargetGender targetGender,
@@ -72,6 +78,7 @@ public class Card extends BaseTimeEntity {
             Integer weight) {
         this.cardImage = cardImage;
         this.tags = tags;
+        this.userId = userId;
         this.originId = originId;
         this.status = CardStatus.PENDING;
         this.platform = platform;
@@ -85,11 +92,16 @@ public class Card extends BaseTimeEntity {
             throw new CardBusinessException(CardErrorCode.CARD_ORIGIN_ID_IS_REQUIRED_TO_CREATE);
         }
 
+        if (command.platform() == null) {
+            throw new CardBusinessException(CardErrorCode.CARD_PLATFORM_IS_REQUIRED_TO_CREATE);
+        }
+
         CardImage cardImage = CardImage.create(command.cardImage());
 
         Card card = new Card(
                 cardImage,
                 command.tags(),
+                null,
                 command.originId(),
                 command.platform(),
                 command.targetGender(),
@@ -98,6 +110,30 @@ public class Card extends BaseTimeEntity {
 
         cardImage.setCard(card);
         command.productCreateCommands().stream()
+                .map(Product::create)
+                .map(product -> CardProduct.create(card, product))
+                .forEach(card.cardProducts::add);
+        return card;
+    }
+
+    public static Card createByUser(
+            Long userId,
+            CardImageCreateCommand cardImageCommand,
+            List<ProductCreateCommand> productCommands,
+            String tags,
+            Integer height,
+            Integer weight,
+            TargetGender targetGender) {
+        if (userId == null) {
+            throw new CardBusinessException(CardErrorCode.CARD_USER_ID_IS_REQUIRED_TO_CREATE);
+        }
+
+        CardImage cardImage = CardImage.create(cardImageCommand);
+
+        Card card = new Card(cardImage, tags, userId, null, null, targetGender, height, weight);
+
+        cardImage.setCard(card);
+        productCommands.stream()
                 .map(Product::create)
                 .map(product -> CardProduct.create(card, product))
                 .forEach(card.cardProducts::add);

--- a/src/main/java/com/dekk/app/card/domain/model/enums/TargetGender.java
+++ b/src/main/java/com/dekk/app/card/domain/model/enums/TargetGender.java
@@ -1,5 +1,6 @@
 package com.dekk.app.card.domain.model.enums;
 
+import com.dekk.app.user.domain.model.enums.Gender;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,6 +13,18 @@ public enum TargetGender {
     UNDEFINED("미정");
 
     private final String description;
+
+    public static TargetGender fromGender(Gender gender) {
+        if (gender == null) {
+            return UNDEFINED;
+        }
+
+        return switch (gender) {
+            case MALE -> MEN;
+            case FEMALE -> WOMEN;
+            case OTHER -> OTHER;
+        };
+    }
 
     public static TargetGender musinsaParse(String value) {
         if (value == null || value.isBlank()) {


### PR DESCRIPTION
## #️⃣연관된 이슈
[지라 티켓 번호](https://potenup-final.atlassian.net/browse/DK-418)

## 📝작업 내용
- 사용자에 의한 카드 생성 로직을 작성했습니다.

## 💬리뷰 요구사항(선택)
고민이 되는 부분이 있습니다. 
- 크롤링에서 카드 생성하는 것을 중지하고 관련 로직을 완전히 제거할 건지? -> 제거 한다면 originId, platform을 데이터베이스에서 완전히 제거할 수 있습니다. 
- weight, height, targetGender 정보를 사용자의 정보 그대로 매핑 할 건지, 아니면 카드 생성마다 사용자 지정으로 받을지 (예를 들어 어머니가 자신의 계정으로 아이의 룩북을 올리는 경우)