### PR TITLE
[REFACTOR] 추천 카드 조회 API에 Slice 적용

### DIFF
--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
@@ -15,6 +15,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,8 +34,9 @@ public class RecommendQueryService {
     private final CardCategoryQueryService cardCategoryQueryService;
     private final RecommendScoringService recommendScoringService;
 
-    public List<RecommendCardResult> getRecommendCards(Long userId, int size) {
-        int recommendCount = (int) Math.ceil(size * RECOMMEND_RATIO);
+    public Page<RecommendCardResult> getRecommendCards(Long userId, Pageable pageable) {
+        int totalNeeded = (int) (pageable.getOffset() + pageable.getPageSize());
+        int recommendCount = (int) Math.ceil(totalNeeded * RECOMMEND_RATIO);
 
         Set<Long> swipedIds = activeLogQueryService.getAllSwipedCardIds(userId);
 
@@ -42,14 +46,18 @@ public class RecommendQueryService {
         Set<Long> excludeForNormal = new HashSet<>(swipedIds);
         recommendCards.forEach(c -> excludeForNormal.add(c.cardId()));
 
-        int normalCount = size - recommendCards.size();
+        int normalCount = totalNeeded - recommendCards.size();
         List<MemberCardResult> normalCards = cardQueryService.getLatestCards(excludeForNormal, normalCount);
 
-        List<RecommendCardResult> result = new ArrayList<>(recommendCards.size() + normalCards.size());
-        recommendCards.forEach(c -> result.add(RecommendCardResult.recommended(c)));
-        normalCards.forEach(c -> result.add(RecommendCardResult.normal(c)));
+        List<RecommendCardResult> allResults = new ArrayList<>(recommendCards.size() + normalCards.size());
+        recommendCards.forEach(c -> allResults.add(RecommendCardResult.recommended(c)));
+        normalCards.forEach(c -> allResults.add(RecommendCardResult.normal(c)));
 
-        return result;
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), allResults.size());
+        List<RecommendCardResult> pageContent = start >= allResults.size() ? List.of() : allResults.subList(start, end);
+
+        return new PageImpl<>(pageContent, pageable, allResults.size());
     }
 
     private List<MemberCardResult> rankCandidates(Long userId, Set<Long> swipedIds) {

--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
@@ -10,14 +10,14 @@ import com.dekk.app.card.recommend.application.dto.RecommendCardResult;
 import com.dekk.app.user.application.UserQueryService;
 import com.dekk.app.user.application.dto.result.UserInfoResult;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -34,48 +34,69 @@ public class RecommendQueryService {
     private final CardCategoryQueryService cardCategoryQueryService;
     private final RecommendScoringService recommendScoringService;
 
-    public Page<RecommendCardResult> getRecommendCards(Long userId, Pageable pageable) {
+    public Slice<RecommendCardResult> getRecommendCards(Long userId, Pageable pageable) {
         int totalNeeded = (int) (pageable.getOffset() + pageable.getPageSize());
         int recommendCount = (int) Math.ceil(totalNeeded * RECOMMEND_RATIO);
 
         Set<Long> swipedIds = activeLogQueryService.getAllSwipedCardIds(userId);
-
         List<MemberCardResult> recommendCards =
                 rankCandidates(userId, swipedIds).stream().limit(recommendCount).toList();
 
-        Set<Long> excludeForNormal = new HashSet<>(swipedIds);
-        recommendCards.forEach(c -> excludeForNormal.add(c.cardId()));
-
+        Set<Long> recommendIds = extractCardIds(recommendCards);
         int normalCount = totalNeeded - recommendCards.size();
-        List<MemberCardResult> normalCards = cardQueryService.getLatestCards(excludeForNormal, normalCount);
+        List<MemberCardResult> normalCards = fetchNormalCards(swipedIds, recommendIds, normalCount);
 
-        List<RecommendCardResult> allResults = new ArrayList<>(recommendCards.size() + normalCards.size());
-        recommendCards.forEach(c -> allResults.add(RecommendCardResult.recommended(c)));
-        normalCards.forEach(c -> allResults.add(RecommendCardResult.normal(c)));
+        List<RecommendCardResult> allResults = mergeRecommendResults(recommendCards, normalCards);
+        return toSlice(allResults, pageable, totalNeeded);
+    }
 
+    private Set<Long> extractCardIds(List<MemberCardResult> cards) {
+        return cards.stream().map(MemberCardResult::cardId).collect(Collectors.toSet());
+    }
+
+    // 추천 카드 IDs는 DB exclude 대신 in-memory 필터로 확실히 제거
+    // recommendIds.size()만큼 오버 패치하여 필터 후에도 normalCount를 채울 수 있도록 보장
+    private List<MemberCardResult> fetchNormalCards(Set<Long> swipedIds, Set<Long> recommendIds, int normalCount) {
+        List<MemberCardResult> candidates =
+                cardQueryService.getLatestCards(swipedIds, normalCount + recommendIds.size());
+        return candidates.stream()
+                .filter(c -> !recommendIds.contains(c.cardId()))
+                .limit(normalCount)
+                .toList();
+    }
+
+    private List<RecommendCardResult> mergeRecommendResults(
+            List<MemberCardResult> recommendCards, List<MemberCardResult> normalCards) {
+        List<RecommendCardResult> results = new ArrayList<>(recommendCards.size() + normalCards.size());
+        recommendCards.forEach(c -> results.add(RecommendCardResult.recommended(c)));
+        normalCards.forEach(c -> results.add(RecommendCardResult.normal(c)));
+        return results;
+    }
+
+    private Slice<RecommendCardResult> toSlice(
+            List<RecommendCardResult> allResults, Pageable pageable, int totalNeeded) {
         int start = (int) pageable.getOffset();
         int end = Math.min(start + pageable.getPageSize(), allResults.size());
-        List<RecommendCardResult> pageContent = start >= allResults.size() ? List.of() : allResults.subList(start, end);
-
-        return new PageImpl<>(pageContent, pageable, allResults.size());
+        List<RecommendCardResult> content = start >= allResults.size() ? List.of() : allResults.subList(start, end);
+        boolean hasNext = allResults.size() >= totalNeeded;
+        return new SliceImpl<>(content, pageable, hasNext);
     }
 
     private List<MemberCardResult> rankCandidates(Long userId, Set<Long> swipedIds) {
         UserInfoResult userInfo = userQueryService.getMyInfo(userId);
-
         List<MemberCardResult> candidates = fetchCandidates(userInfo).stream()
                 .filter(card -> !swipedIds.contains(card.cardId()))
                 .toList();
-
-        List<Long> likedCategoryIds = getLikedCategoryIds(userId);
-        Map<Long, Double> preferences = recommendScoringService.calculateCategoryPreferenceRatios(likedCategoryIds);
-
-        List<Long> candidateCardIds =
-                candidates.stream().map(MemberCardResult::cardId).toList();
-        Map<Long, List<Long>> cardCategoryMap = cardCategoryQueryService.getCardCategoryMap(candidateCardIds);
-
+        Map<Long, Double> preferences = buildCategoryPreferences(userId);
+        Map<Long, List<Long>> cardCategoryMap = cardCategoryQueryService.getCardCategoryMap(
+                candidates.stream().map(MemberCardResult::cardId).toList());
         return recommendScoringService.rank(
                 userInfo.height(), userInfo.weight(), candidates, cardCategoryMap, preferences);
+    }
+
+    private Map<Long, Double> buildCategoryPreferences(Long userId) {
+        List<Long> likedCategoryIds = getLikedCategoryIds(userId);
+        return recommendScoringService.calculateCategoryPreferenceRatios(likedCategoryIds);
     }
 
     private List<MemberCardResult> fetchCandidates(UserInfoResult userInfo) {

--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
@@ -15,18 +15,22 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class RecommendQueryService {
 
     private static final double RECOMMEND_RATIO = 0.7;
+    private static final int DEEP_SCROLL_PAGE_THRESHOLD = 10;
+    private static final int LARGE_CANDIDATE_THRESHOLD = 500;
 
     private final CardQueryService cardQueryService;
     private final UserQueryService userQueryService;
@@ -38,13 +42,39 @@ public class RecommendQueryService {
         int totalNeeded = (int) (pageable.getOffset() + pageable.getPageSize());
         int recommendCount = (int) Math.ceil(totalNeeded * RECOMMEND_RATIO);
 
-        Set<Long> swipedIds = activeLogQueryService.getAllSwipedCardIds(userId);
-        List<MemberCardResult> recommendCards =
-                rankCandidates(userId, swipedIds).stream().limit(recommendCount).toList();
+        if (pageable.getPageNumber() >= DEEP_SCROLL_PAGE_THRESHOLD) {
+            log.warn("[Recommend] 깊은 스크롤 감지 userId={} page={} - 컨텐츠 다양성 부족 가능성", userId, pageable.getPageNumber());
+        }
 
+        Set<Long> swipedIds = activeLogQueryService.getAllSwipedCardIds(userId);
+        log.debug(
+                "[Recommend] userId={} swipedCount={} totalNeeded={} recommendTarget={}",
+                userId,
+                swipedIds.size(),
+                totalNeeded,
+                recommendCount);
+
+        List<MemberCardResult> rankedCandidates = rankCandidates(userId, swipedIds);
+
+        if (rankedCandidates.size() < recommendCount) {
+            log.warn(
+                    "[Recommend] 후보군 부족 userId={} candidateCount={} recommendTarget={}",
+                    userId,
+                    rankedCandidates.size(),
+                    recommendCount);
+        }
+
+        List<MemberCardResult> recommendCards =
+                rankedCandidates.stream().limit(recommendCount).toList();
         Set<Long> recommendIds = extractCardIds(recommendCards);
         int normalCount = totalNeeded - recommendCards.size();
         List<MemberCardResult> normalCards = fetchNormalCards(swipedIds, recommendIds, normalCount);
+
+        log.debug(
+                "[Recommend] userId={} served: recommend={} normal={}",
+                userId,
+                recommendCards.size(),
+                normalCards.size());
 
         List<RecommendCardResult> allResults = mergeRecommendResults(recommendCards, normalCards);
         return toSlice(allResults, pageable, totalNeeded);
@@ -87,9 +117,24 @@ public class RecommendQueryService {
         List<MemberCardResult> candidates = fetchCandidates(userInfo).stream()
                 .filter(card -> !swipedIds.contains(card.cardId()))
                 .toList();
+
+        if (candidates.size() >= LARGE_CANDIDATE_THRESHOLD) {
+            log.warn("[Recommend] 대용량 후보군 스코어링 userId={} candidateCount={} - 인메모리 부하 위험", userId, candidates.size());
+        }
         Map<Long, Double> preferences = buildCategoryPreferences(userId);
+
+        if (preferences.isEmpty()) {
+            log.info("[Recommend] cold-start userId={} (카테고리 선호 없음, 체형 기반으로만 추천)", userId);
+        }
+        log.debug(
+                "[Recommend] scoring userId={} candidateCount={} preferenceCategories={}",
+                userId,
+                candidates.size(),
+                preferences.size());
+
         Map<Long, List<Long>> cardCategoryMap = cardCategoryQueryService.getCardCategoryMap(
                 candidates.stream().map(MemberCardResult::cardId).toList());
+
         return recommendScoringService.rank(
                 userInfo.height(), userInfo.weight(), candidates, cardCategoryMap, preferences);
     }

--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendScoringService.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendScoringService.java
@@ -19,7 +19,7 @@ public class RecommendScoringService {
     private static final double CATEGORY_WEIGHT = 0.6;
     private static final double BODY_WEIGHT = 0.4;
 
-    public double calculateBodyScore(int userHeight, int userWeight, Integer cardHeight, Integer cardWeight) {
+    private double calculateBodyScore(int userHeight, int userWeight, Integer cardHeight, Integer cardWeight) {
         double heightScore = calculateDimensionScore(userHeight, cardHeight, HEIGHT_RANGE);
         double weightScore = calculateDimensionScore(userWeight, cardWeight, WEIGHT_RANGE);
         return (heightScore + weightScore) / SCORE_DIMENSION_COUNT;

--- a/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryApi.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryApi.java
@@ -28,6 +28,6 @@ public interface RecommendQueryApi {
             })
     ResponseEntity<ApiResponse<PageResponse<RecommendCardResponse>>> getRecommendCards(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Parameter(description = "반환할 총 카드 수 (최대 50)", example = "10") @RequestParam(defaultValue = "10") @Max(50)
-                    int size);
+            @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 당 카드 수 (최대 50)", example = "10") @RequestParam(defaultValue = "10") @Max(50) int size);
 }

--- a/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryApi.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryApi.java
@@ -29,5 +29,6 @@ public interface RecommendQueryApi {
     ResponseEntity<ApiResponse<PageResponse<RecommendCardResponse>>> getRecommendCards(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
-            @Parameter(description = "페이지 당 카드 수 (최대 50)", example = "10") @RequestParam(defaultValue = "10") @Max(50) int size);
+            @Parameter(description = "페이지 당 카드 수 (최대 50)", example = "10") @RequestParam(defaultValue = "10") @Max(50)
+                    int size);
 }

--- a/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryApi.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryApi.java
@@ -2,7 +2,7 @@ package com.dekk.app.card.recommend.presentation.controller;
 
 import com.dekk.app.card.recommend.presentation.dto.response.RecommendCardResponse;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.response.PageResponse;
+import com.dekk.global.response.SliceResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -26,7 +26,7 @@ public interface RecommendQueryApi {
                         description = "추천 카드 조회 성공",
                         content = @Content(schema = @Schema(implementation = RecommendCardResponse.class)))
             })
-    ResponseEntity<ApiResponse<PageResponse<RecommendCardResponse>>> getRecommendCards(
+    ResponseEntity<ApiResponse<SliceResponse<RecommendCardResponse>>> getRecommendCards(
             @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 당 카드 수 (최대 50)", example = "10") @RequestParam(defaultValue = "10") @Max(50)

--- a/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryController.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryController.java
@@ -6,8 +6,9 @@ import com.dekk.app.card.recommend.presentation.response.RecommendResultCode;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -25,11 +26,15 @@ public class RecommendQueryController implements RecommendQueryApi {
     @Override
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<RecommendCardResponse>>> getRecommendCards(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @RequestParam(defaultValue = "10") int size) {
-        List<RecommendCardResponse> cards =
-                RecommendCardResponse.from(recommendQueryService.getRecommendCards(userDetails.getId(), size));
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Pageable pageable = PageRequest.of(page, size);
 
-        return ResponseEntity.ok(
-                ApiResponse.of(RecommendResultCode.RECOMMEND_CARD_SUCCESS, PageResponse.from(cards, size)));
+        return ResponseEntity.ok(ApiResponse.of(
+                RecommendResultCode.RECOMMEND_CARD_SUCCESS,
+                PageResponse.from(recommendQueryService
+                        .getRecommendCards(userDetails.getId(), pageable)
+                        .map(RecommendCardResponse::from))));
     }
 }

--- a/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryController.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryController.java
@@ -4,7 +4,7 @@ import com.dekk.app.card.recommend.application.RecommendQueryService;
 import com.dekk.app.card.recommend.presentation.dto.response.RecommendCardResponse;
 import com.dekk.app.card.recommend.presentation.response.RecommendResultCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.response.PageResponse;
+import com.dekk.global.response.SliceResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -25,7 +25,7 @@ public class RecommendQueryController implements RecommendQueryApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse<PageResponse<RecommendCardResponse>>> getRecommendCards(
+    public ResponseEntity<ApiResponse<SliceResponse<RecommendCardResponse>>> getRecommendCards(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
@@ -33,7 +33,7 @@ public class RecommendQueryController implements RecommendQueryApi {
 
         return ResponseEntity.ok(ApiResponse.of(
                 RecommendResultCode.RECOMMEND_CARD_SUCCESS,
-                PageResponse.from(recommendQueryService
+                SliceResponse.from(recommendQueryService
                         .getRecommendCards(userDetails.getId(), pageable)
                         .map(RecommendCardResponse::from))));
     }

--- a/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryController.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryController.java
@@ -9,6 +9,7 @@ import com.dekk.global.security.oauth2.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -31,10 +32,11 @@ public class RecommendQueryController implements RecommendQueryApi {
             @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size);
 
-        return ResponseEntity.ok(ApiResponse.of(
-                RecommendResultCode.RECOMMEND_CARD_SUCCESS,
-                SliceResponse.from(recommendQueryService
-                        .getRecommendCards(userDetails.getId(), pageable)
-                        .map(RecommendCardResponse::from))));
+        Slice<RecommendCardResponse> result = recommendQueryService
+                .getRecommendCards(userDetails.getId(), pageable)
+                .map(RecommendCardResponse::from);
+
+        return ResponseEntity.ok(
+                ApiResponse.of(RecommendResultCode.RECOMMEND_CARD_SUCCESS, SliceResponse.from(result)));
     }
 }

--- a/src/main/java/com/dekk/global/response/PageResponse.java
+++ b/src/main/java/com/dekk/global/response/PageResponse.java
@@ -14,8 +14,4 @@ public record PageResponse<T>(
                 page.getTotalPages(),
                 page.hasNext());
     }
-
-    public static <T> PageResponse<T> from(List<T> list, int pageSize) {
-        return new PageResponse<>(list, 0, pageSize, list.size(), list.isEmpty() ? 0 : 1, false);
-    }
 }

--- a/src/main/java/com/dekk/global/response/SliceResponse.java
+++ b/src/main/java/com/dekk/global/response/SliceResponse.java
@@ -1,0 +1,10 @@
+package com.dekk.global.response;
+
+import java.util.List;
+import org.springframework.data.domain.Slice;
+
+public record SliceResponse<T>(List<T> content, int currentPage, int size, boolean hasNext) {
+    public static <T> SliceResponse<T> from(Slice<T> slice) {
+        return new SliceResponse<>(slice.getContent(), slice.getNumber(), slice.getSize(), slice.hasNext());
+    }
+}

--- a/src/test/java/com/dekk/card/recommend/application/RecommendQueryServiceTest.java
+++ b/src/test/java/com/dekk/card/recommend/application/RecommendQueryServiceTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
 
 @ExtendWith(MockitoExtension.class)
 class RecommendQueryServiceTest {
@@ -75,7 +76,8 @@ class RecommendQueryServiceTest {
             given(activeLogQueryService.getAllSwipedCardIds(USER_ID))
                     .willReturn(Set.of(10L, 20L));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, SIZE);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
 
             List<RecommendCardResult> recommended = recommendedOnly(result);
             assertThat(recommended).hasSize(1);
@@ -93,7 +95,8 @@ class RecommendQueryServiceTest {
             given(activeLogQueryService.getAllSwipedCardIds(USER_ID))
                     .willReturn(Set.of());
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, SIZE);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
 
             assertThat(recommendedOnly(result)).hasSize(2);
         }
@@ -109,7 +112,8 @@ class RecommendQueryServiceTest {
             given(activeLogQueryService.getAllSwipedCardIds(USER_ID))
                     .willReturn(Set.of(1L, 2L));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, SIZE);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
 
             assertThat(recommendedOnly(result)).isEmpty();
         }
@@ -138,7 +142,8 @@ class RecommendQueryServiceTest {
             given(cardQueryService.getLatestCards(any(), anyInt()))
                     .willReturn(memberCards(100L, 101L, 102L));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, 10);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
 
             assertThat(recommendedOnly(result)).hasSize(7);
             assertThat(normalOnly(result)).hasSize(3);
@@ -156,7 +161,8 @@ class RecommendQueryServiceTest {
             given(cardQueryService.getLatestCards(any(), anyInt()))
                     .willReturn(memberCards(100L, 101L, 102L, 103L, 104L, 105L, 106L));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, 10);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
 
             assertThat(recommendedOnly(result)).hasSize(3);
             assertThat(normalOnly(result)).hasSize(7);
@@ -172,7 +178,8 @@ class RecommendQueryServiceTest {
             given(cardQueryService.getLatestCards(any(), anyInt()))
                     .willReturn(memberCards(100L));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, 10);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
 
             assertThat(result).anyMatch(RecommendCardResult::recommended);
             assertThat(result).anyMatch(r -> !r.recommended());
@@ -189,7 +196,8 @@ class RecommendQueryServiceTest {
             given(cardQueryService.getLatestCards(any(), anyInt()))
                     .willReturn(memberCards(100L, 101L));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, 10);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
 
             Set<Long> recommendedIds = recommendedOnly(result).stream()
                     .map(r -> r.card().cardId())
@@ -223,7 +231,8 @@ class RecommendQueryServiceTest {
         void shouldQueryAllGenders_whenGenderIsNull() {
             given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(null, 170, 65));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, SIZE);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
 
             assertThat(result).isEmpty();
         }
@@ -235,7 +244,8 @@ class RecommendQueryServiceTest {
             List<Card> candidates = mockCards(1L);
             given(cardQueryService.getRecommendCandidates(any())).willReturn(candidates);
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, SIZE);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
 
             assertThat(recommendedOnly(result)).hasSize(1);
         }
@@ -262,7 +272,8 @@ class RecommendQueryServiceTest {
             given(recommendScoringService.rank(any(), any(), any(), any(), any()))
                     .willAnswer(inv -> inv.getArgument(2));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, SIZE);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
 
             assertThat(result).isEmpty();
         }
@@ -277,7 +288,8 @@ class RecommendQueryServiceTest {
             given(recommendScoringService.rank(any(), any(), any(), any(), any()))
                     .willAnswer(inv -> inv.getArgument(2));
 
-            List<RecommendCardResult> result = recommendQueryService.getRecommendCards(USER_ID, SIZE);
+            List<RecommendCardResult> result =
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
 
             assertThat(result).isEmpty();
         }

--- a/src/test/java/com/dekk/card/recommend/application/RecommendScoringServiceTest.java
+++ b/src/test/java/com/dekk/card/recommend/application/RecommendScoringServiceTest.java
@@ -10,44 +10,10 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 class RecommendScoringServiceTest {
 
     private final RecommendScoringService scoringService = new RecommendScoringService();
-
-    @Nested
-    @DisplayName("calculateBodyScore")
-    class CalculateBodyScore {
-
-        @ParameterizedTest(name = "{5}")
-        @CsvSource({
-                "175, 70, 175, 70, 1.0,    키와 몸무게가 완전히 일치하면 1.0을 반환한다",
-                "175, 70, 180, 77, 0.0,    키와 몸무게 차이가 범위 한계와 정확히 같으면 0.0을 반환한다",
-                "175, 70, 178, 74, 0.4143, 체형 차이에 따라 정확한 점수를 반환한다",
-        })
-        void shouldReturnExpectedScore(int uh, int uw, int ch, int cw, double expected, String description) {
-            assertThat(scoringService.calculateBodyScore(uh, uw, ch, cw))
-                    .isCloseTo(expected, within(0.001));
-        }
-
-        @Test
-        @DisplayName("범위를 초과한 차이는 음수가 되지 않고 0.0으로 보정된다")
-        void shouldClampTo0_whenDiffExceedsRange() {
-            // height diff = 15 → 1 - 15/5 = -2.0  →  Math.max(0.0, -2.0) = 0.0
-            // weight diff = 20 → 1 - 20/7 = -1.857.. →  Math.max(0.0, -1.857) = 0.0
-            assertThat(scoringService.calculateBodyScore(175, 70, 190, 90))
-                    .isGreaterThanOrEqualTo(0.0);
-        }
-
-        @Test
-        @DisplayName("카드 체형 정보가 없으면 체형 제한 없는 카드로 간주해 1.0을 반환한다")
-        void shouldReturn1_whenCardBodyInfoIsNull() {
-            assertThat(scoringService.calculateBodyScore(175, 70, null, null))
-                    .isCloseTo(1.0, within(0.001));
-        }
-    }
 
     @Nested
     @DisplayName("calculateCategoryPreferenceRatios")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[DK-397](https://potenup-final.atlassian.net/browse/DK-397)


## 📝 작업 내용
#### 신규 추가
- `src/main/java/com/dekk/global/response/SliceResponse.java`
  - `Slice<T>` → `{ content, currentPage, size, hasNext }` 변환 record

#### 수정
- `RecommendQueryService.java`
  - 반환 타입: `Page<RecommendCardResult>` → `Slice<RecommendCardResult>`
  - `PageImpl` → `SliceImpl` 사용
  - `hasNext` 판단: `allResults.size() >= totalNeeded`
  - 로직 분리 리팩터링:
    - `extractCardIds()` — 추천 카드 ID Set 추출
    - `fetchNormalCards()` — 일반 카드 조회 (in-memory 필터로 추천 카드 중복 제거)
    - `mergeRecommendResults()` — 추천 + 일반 카드 병합
    - `toSlice()` — 페이지 슬라이싱 및 SliceImpl 생성
    - `buildCategoryPreferences()` — 카테고리 선호도 계산 위임

- `RecommendQueryApi.java`
  - 응답 타입: `PageResponse<RecommendCardResponse>` → `SliceResponse<RecommendCardResponse>`

- `RecommendQueryController.java`
  - 응답 타입 및 `PageResponse.from()` → `SliceResponse.from()` 변경
## 💬 리뷰 요구사항

### 현재 페이지네이션 구현의 한계

이번 PR은 API 인터페이스를 `Pageable` 구조로 전환하는 것에 집중했습니다.
다만 내부 구현에 아래 두 가지 구조적 문제가 남아 있어 방향 결정이 필요합니다.

**1. `totalElements` 부정확**
```java
int totalNeeded = (int) (pageable.getOffset() + pageable.getPageSize());
return new PageImpl<>(pageContent, pageable, allResults.size()); // allResults.size() == totalNeeded
```

`totalElements`가 실제 전체 카드 수가 아닌 `offset + pageSize`로 반환됩니다.
현재 클라이언트가 `totalPages / hasNext`를 활용하는지 확인이 필요합니다.

**2. 매 페이지 요청마다 누적 재조회**
```
page=0, size=10 → 10건 fetch
page=1, size=10 → 20건 fetch  (page=0 포함)
```

페이지가 깊어질수록 조회량이 선형으로 증가합니다.

### 논의 포인트 (완료)

- **무한 스크롤**이라면 → 커서 기반(`lastCardId`)으로 전환하는 것이 자연스럽고, 위 두 문제가 모두 해결됩니다.
- **페이지 번호 UI**라면 → 추천 결과를 Redis에 세션 단위로 캐시하고 이후 요청은 slice만 꺼내는 방식을 검토해야 합니다.
- `totalElements`를 클라이언트가 실제로 사용하는지 여부에 따라 대응 방식이 달라집니다. @monegit 

## 논의 후 (Page -> Slice)

### 1. 왜 Slice인가

#### Page가 가진 구조적 문제

현재 추천 서비스에서 `Page`를 사용하면 다음 계산이 발생합니다.

```
page=0 요청 → totalElements: 10
page=1 요청 → totalElements: 20
page=2 요청 → totalElements: 30
```

요청할 때마다 `totalNeeded`가 늘어나고, 그에 맞춰 `allResults.size()`도 커지기 때문에 **`totalElements`가 매 요청마다 달라집니다.**

- 클라이언트는 page=0에서 `totalPages: 1`을 받고 "마지막 페이지"로 판단
- 실제로는 다음 페이지가 계속 존재
- 총 페이지 수를 표시하거나 "N/M 페이지" UI를 구현하는 것 자체가 불가능

추가로 **Ranking Drift** 문제도 있습니다. page=0에서 본 카드가 page=1 요청 시 재채점되어 순위가 바뀌면, 이미 본 카드가 다시 나오거나 못 본 카드가 누락될 수 있습니다.

#### Page vs Slice 비교

| 항목 | Page | Slice |
|------|------|-------|
| **반환 정보** | content + totalElements + totalPages + hasNext | content + hasNext |
| **COUNT 쿼리** | 필요 (DB 또는 in-memory 계산) | 불필요 |
| **무한 스크롤 적합성** | △ (totalElements가 쓸모없거나 부정확) | ✅ (hasNext만으로 충분) |
| **특정 페이지 이동** | 가능 | 불가 |
| **추천 피드 적합성** | ❌ (totalElements 보장 불가) | ✅ |

#### 우리 서비스에서 Slice여야 하는 이유

1. **무한 스크롤 UX**
2. **totalElements 계산이 애초에 불가능**
3. **페이지 간 순서 보장이 약한 구조** 
4. **향후 Snapshot Pagination으로의 전환 고려한 구조**(아래 성률님이 말씀해주셨던 방식)

> 결론: 추천 피드는 "총 N개 중 M번째"가 아니라 "다음이 있는지"만 알면 된다. Page가 제공하는 정보의 절반이 이 서비스에서는 의미 없거나 오히려 잘못된 값이다.

---

### 2. 왜 in-memory 필터인가 — 스와이프 제외 방식 결정

추천 카드 후보군에서 이미 스와이프한 카드를 제외하는 방법으로 세 가지를 검토했습니다.

#### 방법 1: `excludedCardIds`를 Card 쿼리 파라미터로 전달

```sql
AND c.id NOT IN :excludedCardIds
```

- Bounded Context는 지키지만, 스와이프가 쌓일수록 `IN` 절이 무한정 커집니다.
- 스와이프가 많은 사용자일수록 쿼리가 느려지는 구조적 문제가 있습니다.

#### 방법 2: Card 쿼리 내부에서 ActiveLog 서브쿼리

```sql
AND c.id NOT IN (SELECT al.cardId FROM ActiveLog al WHERE al.userId = :userId)
```

- DB 왕복 1회로 깔끔하지만 **Bounded Context를 침범**하게 됩니다.
- `CardJpaRepository`(Card 도메인 인프라)가 `ActiveLog`(다른 도메인)를 직접 참조하게 됩니다.
- ActiveLog 구조가 바뀌면 Card 쿼리도 함께 수정해야 하는 강한 결합이 발생합니다.

#### 방법 3: 애플리케이션 레이어 필터링 (채택!!)

```java
candidates.stream()
    .filter(c -> !swipedIds.contains(c.cardId()))
    .toList()
```

- Card 쿼리는 성별&체형 스펙 필터링만 담당, ActiveLog를 전혀 모름.
- `IN` 절 크기 문제 없음.
- Bounded Context 완전 준수!

**단점이 허용 가능한 이유:**
- 성별 + 체형(±5cm, ±7kg) 필터로 이미 후보군이 크게 줄어든 상태 (~13,000개 전체 카드 중 훨씬 적은 수)입니다.
- 스와이프가 많아도 쿼리 자체가 느려지지 않는다. 서비스 레이어 메모리 필터 비용은 후보군 크기에 비례하는데, 이미 스펙 필터로 좁혀진 이후라 허용 가능한 수준입니다.
- `HashSet.contains()`는 O(1)이라 수천 개 필터링도 빠릅니다.

#### 일반 카드(normal) 조회에서의 in-memory 중복 제거

추천 카드 IDs를 DB `NOT IN`으로 넘기는 대신, DB에서는 `swipedIds`만 제외하고 `recommendIds.size()`만큼 over-fetch한 뒤 메모리에서 제거합니다.

```java
// over-fetch: normalCount + recommendIds.size()만큼 가져온 뒤
candidates.stream()
    .filter(c -> !recommendIds.contains(c.cardId()))
    .limit(normalCount)
    .toList()
```

이 방식을 택한 이유:
- 추천 카드 ID 목록을 DB 파라미터로 넘기면 `IN` 절이 커지고 쿼리 복잡도 증가
- 추천 카드는 보통 10개 내외(size × 0.7)라 over-fetch 비용이 미미함
- 필터 후에도 `normalCount`를 확실히 채울 수 있도록 보장하는 가장 단순한 방법

---

> [추천 로직 흐름](https://www.notion.so/32281e1db41d801ea70efc881bff59cb?source=copy_link)은 Notion에 정리해뒀습니다!

[DK-397]: https://potenup-final.atlassian.net/browse/DK-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ