### PR TITLE
[REFACTOR] Presentation 계층 Response DTO 캡슐화 및 Result 누수 차단(#DK-430)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ src/main/resources/application-dev.yml
 
 # yml 파일 이름에 secret이나 prod가 들어간다면 패턴으로 모두 무시
 *secret*.yml
+
+# Querydsl Q-Class 생성 디렉터리 무시
+src/main/generated/

--- a/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryApi.java
@@ -10,9 +10,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
-
 import java.util.List;
-
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "커스텀덱 조회 API", description = "커스텀덱 목록 및 상태 조회 API")
@@ -22,15 +20,15 @@ public interface CustomDeckQueryApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20008)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<List<CustomDeckResponse>>> getMyCustomDecks(
-        @Parameter(hidden = true) CustomUserDetails userDetails);
+            @Parameter(hidden = true) CustomUserDetails userDetails);
 
     @Operation(
-        summary = "커스텀덱(쉐어덱) 내부 카드 목록 조회",
-        description =
-            "특정 커스텀덱(쉐어덱)에 담긴 카드 목록을 덱의 메타데이터(타입, 공유 토큰 등) 및 현재 유저의 권한(HOST/GUEST)과 함께 최신순으로 전체 조회합니다. (최대 50장)")
+            summary = "커스텀덱(쉐어덱) 내부 카드 목록 조회",
+            description =
+                    "특정 커스텀덱(쉐어덱)에 담긴 카드 목록을 덱의 메타데이터(타입, 공유 토큰 등) 및 현재 유저의 권한(HOST/GUEST)과 함께 최신순으로 전체 조회합니다. (최대 50장)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20011)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<CustomDeckCardsResponse>> getCustomDeckCards(
-        @Parameter(hidden = true) CustomUserDetails userDetails,
-        @Parameter(description = "조회할 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(description = "조회할 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryApi.java
@@ -1,8 +1,8 @@
 package com.dekk.app.deck.presentation.controller;
 
-import com.dekk.app.deck.application.dto.result.CustomDeckResult;
 import com.dekk.app.deck.domain.exception.DeckErrorCode;
 import com.dekk.app.deck.presentation.response.CustomDeckCardsResponse;
+import com.dekk.app.deck.presentation.response.CustomDeckResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
 import com.dekk.global.swagger.ApiErrorExceptions;
@@ -10,7 +10,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.tags.Tag;
+
 import java.util.List;
+
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "커스텀덱 조회 API", description = "커스텀덱 목록 및 상태 조회 API")
@@ -19,16 +21,16 @@ public interface CustomDeckQueryApi {
     @Operation(summary = "내 커스텀덱(쉐어덱) 목록 조회", description = "사용자가 생성한 커스텀덱 목록과 최신 카드 썸네일(imageUrl) 1장을 최신순으로 조회합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20008)")
     @ApiErrorExceptions({DeckErrorCode.class})
-    ResponseEntity<ApiResponse<List<CustomDeckResult>>> getMyCustomDecks(
-            @Parameter(hidden = true) CustomUserDetails userDetails);
+    ResponseEntity<ApiResponse<List<CustomDeckResponse>>> getMyCustomDecks(
+        @Parameter(hidden = true) CustomUserDetails userDetails);
 
     @Operation(
-            summary = "커스텀덱(쉐어덱) 내부 카드 목록 조회",
-            description =
-                    "특정 커스텀덱(쉐어덱)에 담긴 카드 목록을 덱의 메타데이터(타입, 공유 토큰 등) 및 현재 유저의 권한(HOST/GUEST)과 함께 최신순으로 전체 조회합니다. (최대 50장)")
+        summary = "커스텀덱(쉐어덱) 내부 카드 목록 조회",
+        description =
+            "특정 커스텀덱(쉐어덱)에 담긴 카드 목록을 덱의 메타데이터(타입, 공유 토큰 등) 및 현재 유저의 권한(HOST/GUEST)과 함께 최신순으로 전체 조회합니다. (최대 50장)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20011)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<CustomDeckCardsResponse>> getCustomDeckCards(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "조회할 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
+        @Parameter(hidden = true) CustomUserDetails userDetails,
+        @Parameter(description = "조회할 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryController.java
@@ -2,8 +2,8 @@ package com.dekk.app.deck.presentation.controller;
 
 import com.dekk.app.deck.application.CustomDeckQueryService;
 import com.dekk.app.deck.application.dto.result.CustomDeckCardsResult;
-import com.dekk.app.deck.application.dto.result.CustomDeckResult;
 import com.dekk.app.deck.presentation.response.CustomDeckCardsResponse;
+import com.dekk.app.deck.presentation.response.CustomDeckResponse;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
@@ -25,11 +25,14 @@ public class CustomDeckQueryController implements CustomDeckQueryApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CustomDeckResult>>> getMyCustomDecks(
+    public ResponseEntity<ApiResponse<List<CustomDeckResponse>>> getMyCustomDecks(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<CustomDeckResult> result = customDeckQueryService.getMyCustomDecks(userDetails.getId());
 
-        return ResponseEntity.ok(ApiResponse.of(DeckResultCode.CUSTOM_DECK_LIST_SUCCESS, result));
+        List<CustomDeckResponse> response = customDeckQueryService.getMyCustomDecks(userDetails.getId()).stream()
+                .map(CustomDeckResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.of(DeckResultCode.CUSTOM_DECK_LIST_SUCCESS, response));
     }
 
     @Override

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DeckQueryApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DeckQueryApi.java
@@ -1,7 +1,7 @@
 package com.dekk.app.deck.presentation.controller;
 
-import com.dekk.app.deck.application.dto.result.DeckResult;
 import com.dekk.app.deck.domain.exception.DeckErrorCode;
+import com.dekk.app.deck.presentation.response.DeckResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
 import com.dekk.global.swagger.ApiErrorExceptions;
@@ -19,5 +19,5 @@ public interface DeckQueryApi {
             description = "사용자가 참여 중인 모든 덱(기본덱, 커스텀덱, 쉐어덱)을 통합 조회합니다. 기본덱이 최상단에 위치하며, 각 덱의 최신 카드 썸네일(최대 3장)을 포함합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SD20012: 보관함 통합 목록 조회 성공")
     @ApiErrorExceptions({DeckErrorCode.class})
-    ResponseEntity<ApiResponse<List<DeckResult>>> getDecks(@Parameter(hidden = true) CustomUserDetails userDetails);
+    ResponseEntity<ApiResponse<List<DeckResponse>>> getDecks(@Parameter(hidden = true) CustomUserDetails userDetails);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DeckQueryController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DeckQueryController.java
@@ -1,7 +1,7 @@
 package com.dekk.app.deck.presentation.controller;
 
 import com.dekk.app.deck.application.DeckQueryService;
-import com.dekk.app.deck.application.dto.result.DeckResult;
+import com.dekk.app.deck.presentation.response.DeckResponse;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
@@ -22,10 +22,13 @@ public class DeckQueryController implements DeckQueryApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse<List<DeckResult>>> getDecks(
+    public ResponseEntity<ApiResponse<List<DeckResponse>>> getDecks(
             @AuthenticationPrincipal CustomUserDetails userDetails) {
-        List<DeckResult> result = deckQueryService.getDecks(userDetails.getId());
 
-        return ResponseEntity.ok(ApiResponse.of(DeckResultCode.DECK_LIST_SUCCESS, result));
+        List<DeckResponse> response = deckQueryService.getDecks(userDetails.getId()).stream()
+                .map(DeckResponse::from)
+                .toList();
+
+        return ResponseEntity.ok(ApiResponse.of(DeckResultCode.DECK_LIST_SUCCESS, response));
     }
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckQueryApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckQueryApi.java
@@ -1,7 +1,7 @@
 package com.dekk.app.deck.presentation.controller;
 
-import com.dekk.app.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.app.deck.domain.exception.DeckErrorCode;
+import com.dekk.app.deck.presentation.response.MyDeckCardResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
@@ -19,6 +19,6 @@ public interface DefaultDeckQueryApi {
     @Operation(summary = "기본덱 카드 목록 페이징 조회", description = "기본덱의 카드 목록을 페이징하여 조회합니다. (기본 정렬: 최신순)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SDK20002)")
     @ApiErrorExceptions({DeckErrorCode.class})
-    ResponseEntity<ApiResponse<PageResponse<MyDeckCardResult>>> getMyDefaultDeckCards(
+    ResponseEntity<ApiResponse<PageResponse<MyDeckCardResponse>>> getMyDefaultDeckCards(
             @Parameter(hidden = true) CustomUserDetails userDetails, @ParameterObject Pageable pageable);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckQueryController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckQueryController.java
@@ -1,8 +1,8 @@
 package com.dekk.app.deck.presentation.controller;
 
 import com.dekk.app.deck.application.DefaultDeckQueryService;
-import com.dekk.app.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
+import com.dekk.app.deck.presentation.response.MyDeckCardResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
@@ -27,11 +27,15 @@ public class DefaultDeckQueryController implements DefaultDeckQueryApi {
 
     @Override
     @GetMapping("/cards")
-    public ResponseEntity<ApiResponse<PageResponse<MyDeckCardResult>>> getMyDefaultDeckCards(
+    public ResponseEntity<ApiResponse<PageResponse<MyDeckCardResponse>>> getMyDefaultDeckCards(
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
-        Page<MyDeckCardResult> pageResult = deckQueryService.getMyDefaultDeckCards(userDetails.getId(), pageable);
 
-        return ResponseEntity.ok(ApiResponse.of(DeckResultCode.DECK_CARD_LIST_SUCCESS, PageResponse.from(pageResult)));
+        Page<MyDeckCardResponse> responsePage = deckQueryService
+                .getMyDefaultDeckCards(userDetails.getId(), pageable)
+                .map(MyDeckCardResponse::from);
+
+        return ResponseEntity.ok(
+                ApiResponse.of(DeckResultCode.DECK_CARD_LIST_SUCCESS, PageResponse.from(responsePage)));
     }
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandApi.java
@@ -1,8 +1,8 @@
 package com.dekk.app.deck.presentation.controller;
 
-import com.dekk.app.deck.application.dto.result.ShareTokenResult;
 import com.dekk.app.deck.domain.exception.DeckErrorCode;
 import com.dekk.app.deck.presentation.request.SharedDeckJoinRequest;
+import com.dekk.app.deck.presentation.response.ShareTokenResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
 import com.dekk.global.swagger.ApiErrorExceptions;
@@ -17,40 +17,40 @@ import org.springframework.http.ResponseEntity;
 public interface ShareDeckCommandApi {
 
     @Operation(
-            summary = "쉐어덱 공유 켜기 및 링크 발급 (호스트 전용)",
-            description =
-                    "보관함 상태를 SHARED로 변경하고 24시간 유효한 초대 토큰을 발급합니다. 이미 켜져 있고 남은 시간이 10분 초과일 경우 기존 토큰을 반환(멱등성)하며, 10분 이하일 경우 새 토큰을 발급하고 구 토큰은 10분 뒤 자연 소멸되도록 오버랩합니다.")
+        summary = "쉐어덱 공유 켜기 및 링크 발급 (호스트 전용)",
+        description =
+            "보관함 상태를 SHARED로 변경하고 24시간 유효한 초대 토큰을 발급합니다. 이미 켜져 있고 남은 시간이 10분 초과일 경우 기존 토큰을 반환(멱등성)하며, 10분 이하일 경우 새 토큰을 발급하고 구 토큰은 10분 뒤 자연 소멸되도록 오버랩합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20013)")
     @ApiErrorExceptions({DeckErrorCode.class})
-    ResponseEntity<ApiResponse<ShareTokenResult>> turnOnShare(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "공유를 켤 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
+    ResponseEntity<ApiResponse<ShareTokenResponse>> turnOnShare(
+        @Parameter(hidden = true) CustomUserDetails userDetails,
+        @Parameter(description = "공유를 켤 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
 
     @Operation(
-            summary = "쉐어덱 공유 끄기 (호스트 전용)",
-            description = "덱 상태를 CUSTOM으로 되돌리고, 발급된 토큰을 파기하며, 참여 중인 GUEST들을 모두 내보내기(Soft Delete) 처리합니다.")
+        summary = "쉐어덱 공유 끄기 (호스트 전용)",
+        description = "덱 상태를 CUSTOM으로 되돌리고, 발급된 토큰을 파기하며, 참여 중인 GUEST들을 모두 내보내기(Soft Delete) 처리합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20014)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> turnOffShare(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "공유를 끌 쉐어덱 ID", in = ParameterIn.PATH) Long customDeckId);
+        @Parameter(hidden = true) CustomUserDetails userDetails,
+        @Parameter(description = "공유를 끌 쉐어덱 ID", in = ParameterIn.PATH) Long customDeckId);
 
     @Operation(
-            summary = "초대 링크로 쉐어덱 참여 (게스트 전용)",
-            description = "초대 링크의 토큰을 사용하여 쉐어덱에 GUEST 권한으로 참여합니다. 덱 총량(9개) 제한의 영향을 받습니다.")
+        summary = "초대 링크로 쉐어덱 참여 (게스트 전용)",
+        description = "초대 링크의 토큰을 사용하여 쉐어덱에 GUEST 권한으로 참여합니다. 덱 총량(9개) 제한의 영향을 받습니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20015)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> joinSharedDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @RequestBody(description = "참여용 토큰 정보") SharedDeckJoinRequest request);
+        @Parameter(hidden = true) CustomUserDetails userDetails,
+        @RequestBody(description = "참여용 토큰 정보") SharedDeckJoinRequest request);
 
     @Operation(
-            summary = "쉐어덱 자진 퇴장 (게스트 전용)",
-            description =
-                    "GUEST 권한을 가진 사용자가 쉐어덱에서 자진 퇴장(Soft Delete)합니다. HOST는 이 API를 사용할 수 없으며 '공유 끄기' 또는 '덱 삭제'를 이용해야 합니다.")
+        summary = "쉐어덱 자진 퇴장 (게스트 전용)",
+        description =
+            "GUEST 권한을 가진 사용자가 쉐어덱에서 자진 퇴장(Soft Delete)합니다. HOST는 이 API를 사용할 수 없으며 '공유 끄기' 또는 '덱 삭제'를 이용해야 합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20016)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> leaveSharedDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "퇴장할 쉐어덱 ID", in = ParameterIn.PATH) Long sharedDeckId);
+        @Parameter(hidden = true) CustomUserDetails userDetails,
+        @Parameter(description = "퇴장할 쉐어덱 ID", in = ParameterIn.PATH) Long sharedDeckId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandApi.java
@@ -17,40 +17,40 @@ import org.springframework.http.ResponseEntity;
 public interface ShareDeckCommandApi {
 
     @Operation(
-        summary = "쉐어덱 공유 켜기 및 링크 발급 (호스트 전용)",
-        description =
-            "보관함 상태를 SHARED로 변경하고 24시간 유효한 초대 토큰을 발급합니다. 이미 켜져 있고 남은 시간이 10분 초과일 경우 기존 토큰을 반환(멱등성)하며, 10분 이하일 경우 새 토큰을 발급하고 구 토큰은 10분 뒤 자연 소멸되도록 오버랩합니다.")
+            summary = "쉐어덱 공유 켜기 및 링크 발급 (호스트 전용)",
+            description =
+                    "보관함 상태를 SHARED로 변경하고 24시간 유효한 초대 토큰을 발급합니다. 이미 켜져 있고 남은 시간이 10분 초과일 경우 기존 토큰을 반환(멱등성)하며, 10분 이하일 경우 새 토큰을 발급하고 구 토큰은 10분 뒤 자연 소멸되도록 오버랩합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20013)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<ShareTokenResponse>> turnOnShare(
-        @Parameter(hidden = true) CustomUserDetails userDetails,
-        @Parameter(description = "공유를 켤 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(description = "공유를 켤 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
 
     @Operation(
-        summary = "쉐어덱 공유 끄기 (호스트 전용)",
-        description = "덱 상태를 CUSTOM으로 되돌리고, 발급된 토큰을 파기하며, 참여 중인 GUEST들을 모두 내보내기(Soft Delete) 처리합니다.")
+            summary = "쉐어덱 공유 끄기 (호스트 전용)",
+            description = "덱 상태를 CUSTOM으로 되돌리고, 발급된 토큰을 파기하며, 참여 중인 GUEST들을 모두 내보내기(Soft Delete) 처리합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20014)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> turnOffShare(
-        @Parameter(hidden = true) CustomUserDetails userDetails,
-        @Parameter(description = "공유를 끌 쉐어덱 ID", in = ParameterIn.PATH) Long customDeckId);
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(description = "공유를 끌 쉐어덱 ID", in = ParameterIn.PATH) Long customDeckId);
 
     @Operation(
-        summary = "초대 링크로 쉐어덱 참여 (게스트 전용)",
-        description = "초대 링크의 토큰을 사용하여 쉐어덱에 GUEST 권한으로 참여합니다. 덱 총량(9개) 제한의 영향을 받습니다.")
+            summary = "초대 링크로 쉐어덱 참여 (게스트 전용)",
+            description = "초대 링크의 토큰을 사용하여 쉐어덱에 GUEST 권한으로 참여합니다. 덱 총량(9개) 제한의 영향을 받습니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20015)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> joinSharedDeck(
-        @Parameter(hidden = true) CustomUserDetails userDetails,
-        @RequestBody(description = "참여용 토큰 정보") SharedDeckJoinRequest request);
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @RequestBody(description = "참여용 토큰 정보") SharedDeckJoinRequest request);
 
     @Operation(
-        summary = "쉐어덱 자진 퇴장 (게스트 전용)",
-        description =
-            "GUEST 권한을 가진 사용자가 쉐어덱에서 자진 퇴장(Soft Delete)합니다. HOST는 이 API를 사용할 수 없으며 '공유 끄기' 또는 '덱 삭제'를 이용해야 합니다.")
+            summary = "쉐어덱 자진 퇴장 (게스트 전용)",
+            description =
+                    "GUEST 권한을 가진 사용자가 쉐어덱에서 자진 퇴장(Soft Delete)합니다. HOST는 이 API를 사용할 수 없으며 '공유 끄기' 또는 '덱 삭제'를 이용해야 합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20016)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> leaveSharedDeck(
-        @Parameter(hidden = true) CustomUserDetails userDetails,
-        @Parameter(description = "퇴장할 쉐어덱 ID", in = ParameterIn.PATH) Long sharedDeckId);
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(description = "퇴장할 쉐어덱 ID", in = ParameterIn.PATH) Long sharedDeckId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandController.java
@@ -4,6 +4,7 @@ import com.dekk.app.deck.application.ShareDeckCommandService;
 import com.dekk.app.deck.application.dto.result.ShareTokenResult;
 import com.dekk.app.deck.presentation.request.SharedDeckJoinRequest;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
+import com.dekk.app.deck.presentation.response.ShareTokenResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.oauth2.CustomUserDetails;
 import jakarta.validation.Valid;
@@ -26,10 +27,12 @@ public class ShareDeckCommandController implements ShareDeckCommandApi {
 
     @Override
     @PostMapping("/custom/{customDeckId}/share")
-    public ResponseEntity<ApiResponse<ShareTokenResult>> turnOnShare(
+    public ResponseEntity<ApiResponse<ShareTokenResponse>> turnOnShare(
             @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable("customDeckId") Long customDeckId) {
+
         ShareTokenResult result = shareDeckCommandService.turnOnShareAndGetToken(userDetails.getId(), customDeckId);
-        return ResponseEntity.ok(ApiResponse.of(DeckResultCode.SHARE_DECK_ON_SUCCESS, result));
+
+        return ResponseEntity.ok(ApiResponse.of(DeckResultCode.SHARE_DECK_ON_SUCCESS, ShareTokenResponse.from(result)));
     }
 
     @Override

--- a/src/main/java/com/dekk/app/deck/presentation/response/CustomDeckCardsResponse.java
+++ b/src/main/java/com/dekk/app/deck/presentation/response/CustomDeckCardsResponse.java
@@ -1,7 +1,6 @@
 package com.dekk.app.deck.presentation.response;
 
 import com.dekk.app.deck.application.dto.result.CustomDeckCardsResult;
-import com.dekk.app.deck.application.dto.result.MyDeckCardResult;
 import com.dekk.app.deck.domain.model.enums.DeckRole;
 import com.dekk.app.deck.domain.model.enums.DeckType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -21,9 +20,14 @@ public record CustomDeckCardsResponse(
         @Schema(description = "토큰 만료 남은 시간(초)", example = "86400")
         Long expiredInSeconds,
 
-        @Schema(description = "카드 목록") List<MyDeckCardResult> cards) {
+        @Schema(description = "카드 목록") List<MyDeckCardResponse> cards) {
+
     public static CustomDeckCardsResponse from(CustomDeckCardsResult result) {
         return new CustomDeckCardsResponse(
-                result.deckType(), result.role(), result.token(), result.expiredInSeconds(), result.cards());
+                result.deckType(),
+                result.role(),
+                result.token(),
+                result.expiredInSeconds(),
+                result.cards().stream().map(MyDeckCardResponse::from).toList());
     }
 }

--- a/src/main/java/com/dekk/app/deck/presentation/response/CustomDeckResponse.java
+++ b/src/main/java/com/dekk/app/deck/presentation/response/CustomDeckResponse.java
@@ -1,0 +1,21 @@
+package com.dekk.app.deck.presentation.response;
+
+import com.dekk.app.deck.application.dto.result.CustomDeckResult;
+import com.dekk.app.deck.domain.model.enums.DeckType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "커스텀덱 목록 응답")
+public record CustomDeckResponse(
+        @Schema(description = "덱 ID", example = "2") Long deckId,
+        @Schema(description = "덱 이름", example = "여름 코디") String name,
+
+        @Schema(description = "덱 타입 (CUSTOM/SHARED)", example = "CUSTOM")
+        DeckType deckType,
+
+        @Schema(description = "덱 내 카드 수", example = "5") Long cardCount,
+        @Schema(description = "최신 썸네일 이미지 URL") String imageUrl) {
+    public static CustomDeckResponse from(CustomDeckResult result) {
+        return new CustomDeckResponse(
+                result.deckId(), result.name(), result.deckType(), result.cardCount(), result.imageUrl());
+    }
+}

--- a/src/main/java/com/dekk/app/deck/presentation/response/DeckResponse.java
+++ b/src/main/java/com/dekk/app/deck/presentation/response/DeckResponse.java
@@ -1,0 +1,22 @@
+package com.dekk.app.deck.presentation.response;
+
+import com.dekk.app.deck.application.dto.result.DeckResult;
+import com.dekk.app.deck.domain.model.enums.DeckType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "통합 덱 목록 응답")
+public record DeckResponse(
+        @Schema(description = "덱 ID", example = "1") Long deckId,
+        @Schema(description = "덱 이름", example = "나의 기본 덱") String name,
+
+        @Schema(description = "덱 타입 (DEFAULT/CUSTOM/SHARED)", example = "DEFAULT")
+        DeckType type,
+
+        @Schema(description = "덱 내 카드 수", example = "15") Long cardCount,
+        @Schema(description = "프리뷰 이미지 URL 목록 (최대 3개)") List<String> previewImageUrls) {
+    public static DeckResponse from(DeckResult result) {
+        return new DeckResponse(
+                result.deckId(), result.name(), result.type(), result.cardCount(), result.previewImageUrls());
+    }
+}

--- a/src/main/java/com/dekk/app/deck/presentation/response/MyDeckCardResponse.java
+++ b/src/main/java/com/dekk/app/deck/presentation/response/MyDeckCardResponse.java
@@ -1,0 +1,35 @@
+package com.dekk.app.deck.presentation.response;
+
+import com.dekk.app.deck.application.dto.result.MyDeckCardResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+
+@Schema(description = "내 보관함 카드 상세 응답")
+public record MyDeckCardResponse(
+        @Schema(description = "카드 ID", example = "1") Long cardId,
+        @Schema(description = "카드 이미지 URL") String cardImageUrl,
+        @Schema(description = "키(cm)", example = "175") Integer height,
+        @Schema(description = "몸무게(kg)", example = "65") Integer weight,
+        @Schema(description = "태그 목록") List<String> tag,
+        @Schema(description = "상품 목록") List<ProductDetailResponse> products) {
+    @Schema(description = "보관함 카드 내 상품 상세 응답")
+    public record ProductDetailResponse(
+            @Schema(description = "브랜드명", example = "Nike") String brand,
+            @Schema(description = "상품 구매 링크") String url,
+            @Schema(description = "상품명", example = "에어포스") String name,
+            @Schema(description = "상품 이미지 URL") String productsImageUrl) {
+        public static ProductDetailResponse from(MyDeckCardResult.ProductDetail result) {
+            return new ProductDetailResponse(result.brand(), result.url(), result.name(), result.productsImageUrl());
+        }
+    }
+
+    public static MyDeckCardResponse from(MyDeckCardResult result) {
+        return new MyDeckCardResponse(
+                result.cardId(),
+                result.cardImageUrl(),
+                result.height(),
+                result.weight(),
+                result.tag(),
+                result.products().stream().map(ProductDetailResponse::from).toList());
+    }
+}

--- a/src/main/java/com/dekk/app/deck/presentation/response/ShareTokenResponse.java
+++ b/src/main/java/com/dekk/app/deck/presentation/response/ShareTokenResponse.java
@@ -1,0 +1,16 @@
+package com.dekk.app.deck.presentation.response;
+
+import com.dekk.app.deck.application.dto.result.ShareTokenResult;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "쉐어덱 토큰 발급 응답")
+public record ShareTokenResponse(
+        @Schema(description = "초대 토큰", example = "a1b2c3d4e5f64789b123c456d789e012")
+        String token,
+
+        @Schema(description = "토큰 만료 남은 시간(초)", example = "86400")
+        long expiredInSeconds) {
+    public static ShareTokenResponse from(ShareTokenResult result) {
+        return new ShareTokenResponse(result.token(), result.expiredInSeconds());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

# [DK-430](https://potenup-final.atlassian.net/browse/DK-430)

## 📝작업 내용

Application 계층의 비즈니스 반환 객체(`Result`)가 외부 응답으로 그대로 누수되어 API 스펙과 강결합되는 문제를 해결하기 위해, Presentation 전용 DTO로 캡슐화했습니다.

**1. Presentation 전용 Response DTO 신규 생성 및 수정**
- `DeckResponse`, `CustomDeckResponse`, `MyDeckCardResponse`, `ShareTokenResponse` 추가
- `CustomDeckCardsResponse` 내부 리스트 타입을 `MyDeckCardResult`에서 `MyDeckCardResponse`로 변경하여 중첩된 누수 차단

**2. API Interface 스펙 업데이트 (Swagger)**
- `DeckQueryApi`, `CustomDeckQueryApi`, `DefaultDeckQueryApi`, `ShareDeckCommandApi`의 반환 타입을 모두 `...Response` 객체로 변경

**3. Controller 변환(Mapping) 로직 적용**
- Controller에 `Result`를 `Response`로 변환(`XxxResponse::from`)하는 책임 부여

**4. Querydsl Q-Class Git 추적 방지**
- 로컬 빌드 부산물이 커밋되지 않도록 `.gitignore`에 `src/main/generated/` 경로 추가

### 스크린샷 (선택)
<img width="740" height="757" alt="쉐어덱 공유 켜기 및 링크 발급" src="https://github.com/user-attachments/assets/1f9330f1-b8fe-4d43-a50f-f53b74c03ec0" />
<img width="715" height="556" alt="내 커스텀덱(쉐어덱) 목록 조회" src="https://github.com/user-attachments/assets/e50965fb-8f36-438b-9364-c3b5f81e0c2c" />
<img width="744" height="664" alt="커스텀덱(쉐어덱) 내부 카드 목록 조회" src="https://github.com/user-attachments/assets/52a6f948-6049-4412-964c-496ce0de9472" />
<img width="751" height="710" alt="기본덱 카드 목록 페이징 조회" src="https://github.com/user-attachments/assets/33f352f1-c30b-4610-bbb6-272477db11bd" />
<img width="751" height="751" alt="내 덱 통합 목록 조회" src="https://github.com/user-attachments/assets/53097c7c-7c3e-48fa-a98b-34b715f47080" />



## 💬리뷰 요구사항(선택)

- Application 계층의 `Result` 객체가 Controller 외부 응답으로 노출되는 곳이 남아있는지 확인 부탁드립니다.
- Swagger API 명세서의 반환 모델이 모두 `*Response` 형태로 정상 렌더링 되는지 확인 부탁드립니다.

[DK-430]: https://potenup-final.atlassian.net/browse/DK-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ