### PR TITLE
[FIX] ec2에서 생성한 redis, ssl 이슈 수정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -13,7 +13,7 @@ spring:
       host: ${REDIS_HOST}
       port: ${REDIS_PORT}
       ssl:
-        enabled: true
+        enabled: false
   flyway:
     enabled: true
     locations: classpath:db/migration


### PR DESCRIPTION
## 📝작업 내용
- AWS에서 제공하는 ElastiCache는 기본적으로 ssl을 제공하는데 EC2에 직접 redis를 설치하는 경우 ssl 인증서 발급을 해야 합니다. 과정이 꽤나 복잡해서 ssl 값을 false로 두려 합니다