### PR TITLE
[REFACTOR] User ↔ Deck 이벤트 기반 디커플링 및 동일 이메일 정책 변경(#DK-434)

### DIFF
--- a/src/main/java/com/dekk/app/auth/application/CustomOAuth2UserService.java
+++ b/src/main/java/com/dekk/app/auth/application/CustomOAuth2UserService.java
@@ -1,6 +1,5 @@
 package com.dekk.app.auth.application;
 
-import com.dekk.app.auth.domain.exception.AuthErrorCode;
 import com.dekk.app.user.application.command.UserCreateCommand;
 import com.dekk.app.user.domain.model.User;
 import com.dekk.app.user.domain.model.enums.Provider;
@@ -13,7 +12,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.OAuth2Error;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,18 +43,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             return user.get();
         }
 
-        validateEmailUniqueness(userInfo.getEmail());
-
         return userRepository.save(
                 User.create(new UserCreateCommand(userInfo.getEmail(), provider, userInfo.getProviderId())));
-    }
-
-    private void validateEmailUniqueness(String email) {
-        userRepository.findByEmail(email).ifPresent(existingUser -> {
-            throw new OAuth2AuthenticationException(new OAuth2Error(
-                    AuthErrorCode.DUPLICATE_EMAIL.code(),
-                    existingUser.getProvider().name(),
-                    null));
-        });
     }
 }

--- a/src/main/java/com/dekk/app/auth/domain/exception/AuthErrorCode.java
+++ b/src/main/java/com/dekk/app/auth/domain/exception/AuthErrorCode.java
@@ -13,9 +13,7 @@ public enum AuthErrorCode implements ErrorCode {
     INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "EA40105", "유효하지 않은 리프레시 토큰입니다."),
     INVALID_TOKEN_TYPE(HttpStatus.UNAUTHORIZED, "EA40107", "잘못된 타입의 JWT 토큰 유형입니다."),
 
-    ABNORMAL_TOKEN_ACCESS(HttpStatus.FORBIDDEN, "EA40301", "비정상적인 토큰 접근이 감지되었습니다. 모든 기기에서 로그아웃됩니다."),
-
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "EA40901", "이미 다른 소셜 계정으로 가입된 이메일입니다.");
+    ABNORMAL_TOKEN_ACCESS(HttpStatus.FORBIDDEN, "EA40301", "비정상적인 토큰 접근이 감지되었습니다. 모든 기기에서 로그아웃됩니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/dekk/app/deck/application/handler/UserEventHandler.java
+++ b/src/main/java/com/dekk/app/deck/application/handler/UserEventHandler.java
@@ -1,0 +1,27 @@
+package com.dekk.app.deck.application.handler;
+
+import com.dekk.app.deck.application.DeckWithdrawalCommandService;
+import com.dekk.app.deck.application.DefaultDeckCommandService;
+import com.dekk.global.event.UserDeletedEvent;
+import com.dekk.global.event.UserOnboardedEvent;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserEventHandler {
+
+    private final DefaultDeckCommandService defaultDeckCommandService;
+    private final DeckWithdrawalCommandService deckWithdrawalCommandService;
+
+    @EventListener
+    public void handleUserOnboarded(UserOnboardedEvent event) {
+        defaultDeckCommandService.createDefaultDeck(event.userId());
+    }
+
+    @EventListener
+    public void handleUserDeleted(UserDeletedEvent event) {
+        deckWithdrawalCommandService.processWithdrawal(event.userId());
+    }
+}

--- a/src/main/java/com/dekk/app/deck/application/handler/UserEventHandler.java
+++ b/src/main/java/com/dekk/app/deck/application/handler/UserEventHandler.java
@@ -7,6 +7,8 @@ import com.dekk.global.event.UserOnboardedEvent;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
@@ -16,11 +18,13 @@ public class UserEventHandler {
     private final DeckWithdrawalCommandService deckWithdrawalCommandService;
 
     @EventListener
+    @Transactional(propagation = Propagation.REQUIRED)
     public void handleUserOnboarded(UserOnboardedEvent event) {
         defaultDeckCommandService.createDefaultDeck(event.userId());
     }
 
     @EventListener
+    @Transactional(propagation = Propagation.REQUIRED)
     public void handleUserDeleted(UserDeletedEvent event) {
         deckWithdrawalCommandService.processWithdrawal(event.userId());
     }

--- a/src/main/java/com/dekk/app/user/application/UserAuthCommandService.java
+++ b/src/main/java/com/dekk/app/user/application/UserAuthCommandService.java
@@ -1,0 +1,30 @@
+package com.dekk.app.user.application;
+
+import com.dekk.app.user.application.command.UserCreateCommand;
+import com.dekk.app.user.application.dto.result.UserAuthResult;
+import com.dekk.app.user.domain.model.User;
+import com.dekk.app.user.domain.model.enums.Provider;
+import com.dekk.app.user.domain.repository.UserRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserAuthCommandService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public UserAuthResult getOrRegisterUser(String email, Provider provider, String providerId) {
+        Optional<User> user = userRepository.findByProviderAndProviderId(provider, providerId);
+        if (user.isPresent()) {
+            return UserAuthResult.from(user.get());
+        }
+
+        User newUser = userRepository.save(User.create(new UserCreateCommand(email, provider, providerId)));
+
+        return UserAuthResult.from(newUser);
+    }
+}

--- a/src/main/java/com/dekk/app/user/application/UserCommandService.java
+++ b/src/main/java/com/dekk/app/user/application/UserCommandService.java
@@ -1,7 +1,5 @@
 package com.dekk.app.user.application;
 
-import com.dekk.app.deck.application.DeckWithdrawalCommandService;
-import com.dekk.app.deck.application.DefaultDeckCommandService;
 import com.dekk.app.user.application.command.UserOnboardingCommand;
 import com.dekk.app.user.application.command.UserProfileUpdateCommand;
 import com.dekk.app.user.domain.exception.UserBusinessException;
@@ -9,7 +7,10 @@ import com.dekk.app.user.domain.exception.UserErrorCode;
 import com.dekk.app.user.domain.model.User;
 import com.dekk.app.user.domain.repository.ProfileRepository;
 import com.dekk.app.user.domain.repository.UserRepository;
+import com.dekk.global.event.UserDeletedEvent;
+import com.dekk.global.event.UserOnboardedEvent;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,35 +21,29 @@ public class UserCommandService {
 
     private final UserRepository userRepository;
     private final ProfileRepository profileRepository;
-    private final DefaultDeckCommandService deckCommandService;
-    private final DeckWithdrawalCommandService deckWithdrawalCommandService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public void onboardUser(Long userId, UserOnboardingCommand command) {
         User user = getUser(userId);
-
         validateDuplicateNickname(command.nickname());
 
         user.completeOnboarding(command);
-        userRepository.save(user);
 
-        deckCommandService.createDefaultDeck(user.getId());
+        eventPublisher.publishEvent(UserOnboardedEvent.of(user.getId()));
     }
 
     public void updateProfileInfo(Long userId, UserProfileUpdateCommand command) {
         User user = getUserWithProfile(userId);
-
         if (isNicknameChanged(user, command.nickname())) {
             validateDuplicateNickname(command.nickname());
         }
-
         user.updateProfileInfo(command);
     }
 
     public void deleteUser(Long userId) {
-        deckWithdrawalCommandService.processWithdrawal(userId);
+        eventPublisher.publishEvent(UserDeletedEvent.of(userId));
 
         User user = getUser(userId);
-
         user.deleteUser();
     }
 

--- a/src/main/java/com/dekk/app/user/application/dto/result/UserAuthResult.java
+++ b/src/main/java/com/dekk/app/user/application/dto/result/UserAuthResult.java
@@ -1,0 +1,10 @@
+package com.dekk.app.user.application.dto.result;
+
+import com.dekk.app.user.domain.model.User;
+import com.dekk.app.user.domain.model.enums.UserStatus;
+
+public record UserAuthResult(Long id, String email, String role, UserStatus status) {
+    public static UserAuthResult from(User user) {
+        return new UserAuthResult(user.getId(), user.getEmail(), user.getRole().getKey(), user.getStatus());
+    }
+}

--- a/src/main/java/com/dekk/app/user/domain/model/User.java
+++ b/src/main/java/com/dekk/app/user/domain/model/User.java
@@ -14,11 +14,13 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -26,14 +28,20 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "users")
+@Table(
+        name = "users",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_user_email_provider",
+                    columnNames = {"email", "provider"})
+        })
 public class User extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String email;
 
     @Enumerated(EnumType.STRING)
@@ -51,21 +59,25 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private UserStatus status;
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Profile profile;
 
+    private User(String email, Provider provider, String providerId) {
+        this.email = email;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.status = UserStatus.PENDING;
+        this.role = Role.MEMBER;
+    }
+
     public static User create(UserCreateCommand command) {
-        User user = new User();
-        user.email = command.email();
-        user.provider = command.provider();
-        user.providerId = command.providerId();
-        user.status = UserStatus.PENDING;
-        user.role = Role.MEMBER;
-        return user;
+        return new User(command.email(), command.provider(), command.providerId());
     }
 
     public void completeOnboarding(UserOnboardingCommand command) {
-        validatePendingStatus();
+        if (this.status != UserStatus.PENDING) {
+            throw new UserBusinessException(UserErrorCode.ALREADY_ONBOARDED);
+        }
         this.status = UserStatus.ACTIVE;
         this.profile = Profile.create(this, command);
     }
@@ -79,11 +91,5 @@ public class User extends BaseTimeEntity {
     public void deleteUser() {
         this.status = UserStatus.DELETED;
         this.markAsDeleted();
-    }
-
-    private void validatePendingStatus() {
-        if (this.status != UserStatus.PENDING) {
-            throw new UserBusinessException(UserErrorCode.ALREADY_ONBOARDED);
-        }
     }
 }

--- a/src/main/java/com/dekk/app/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/dekk/app/user/domain/repository/UserRepository.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 public interface UserRepository {
     User save(User user);
 
-    Optional<User> findByEmail(String email);
-
     Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 
     Optional<User> findById(Long id);

--- a/src/main/java/com/dekk/app/user/infrastructure/UserRepositoryImpl.java
+++ b/src/main/java/com/dekk/app/user/infrastructure/UserRepositoryImpl.java
@@ -20,11 +20,6 @@ public class UserRepositoryImpl implements UserRepository {
     }
 
     @Override
-    public Optional<User> findByEmail(String email) {
-        return jpaRepository.findByEmail(email);
-    }
-
-    @Override
     public Optional<User> findByProviderAndProviderId(Provider provider, String providerId) {
         return jpaRepository.findByProviderAndProviderId(provider, providerId);
     }

--- a/src/main/java/com/dekk/app/user/infrastructure/jpa/UserJpaRepository.java
+++ b/src/main/java/com/dekk/app/user/infrastructure/jpa/UserJpaRepository.java
@@ -7,8 +7,6 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserJpaRepository extends JpaRepository<User, Long> {
-    Optional<User> findByEmail(String email);
-
     Optional<User> findByProviderAndProviderId(Provider provider, String providerId);
 
     @EntityGraph(attributePaths = {"profile"})

--- a/src/main/java/com/dekk/global/event/UserDeletedEvent.java
+++ b/src/main/java/com/dekk/global/event/UserDeletedEvent.java
@@ -1,0 +1,7 @@
+package com.dekk.global.event;
+
+public record UserDeletedEvent(Long userId) {
+    public static UserDeletedEvent of(Long userId) {
+        return new UserDeletedEvent(userId);
+    }
+}

--- a/src/main/java/com/dekk/global/event/UserOnboardedEvent.java
+++ b/src/main/java/com/dekk/global/event/UserOnboardedEvent.java
@@ -1,0 +1,7 @@
+package com.dekk.global.event;
+
+public record UserOnboardedEvent(Long userId) {
+    public static UserOnboardedEvent of(Long userId) {
+        return new UserOnboardedEvent(userId);
+    }
+}

--- a/src/main/java/com/dekk/global/security/oauth2/handler/OAuth2ErrorMapper.java
+++ b/src/main/java/com/dekk/global/security/oauth2/handler/OAuth2ErrorMapper.java
@@ -1,6 +1,5 @@
 package com.dekk.global.security.oauth2.handler;
 
-import com.dekk.app.auth.domain.exception.AuthErrorCode;
 import com.dekk.global.error.GlobalErrorCode;
 import com.dekk.global.security.oauth2.dto.ErrorQueryParam;
 import com.dekk.global.security.oauth2.exception.CustomOAuth2Exception;
@@ -13,19 +12,12 @@ import org.springframework.stereotype.Component;
 public class OAuth2ErrorMapper {
 
     public ErrorQueryParam mapError(AuthenticationException exception) {
-
         if (exception instanceof CustomOAuth2Exception customException) {
             return ErrorQueryParam.of(customException.getErrorCode().code(), null);
         }
 
         if (exception instanceof OAuth2AuthenticationException oAuthException) {
             OAuth2Error error = oAuthException.getError();
-
-            if (AuthErrorCode.DUPLICATE_EMAIL.code().equals(error.getErrorCode())) {
-                String provider = error.getDescription() != null ? error.getDescription() : "unknown";
-                return ErrorQueryParam.of(error.getErrorCode(), provider);
-            }
-
             return ErrorQueryParam.of(error.getErrorCode(), null);
         }
 

--- a/src/test/java/com/dekk/user/application/UserCommandServiceTest.java
+++ b/src/test/java/com/dekk/user/application/UserCommandServiceTest.java
@@ -1,14 +1,15 @@
 package com.dekk.user.application;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.dekk.app.deck.application.DeckWithdrawalCommandService;
 import com.dekk.app.user.application.UserCommandService;
 import com.dekk.app.user.domain.model.User;
+import com.dekk.app.user.domain.repository.ProfileRepository;
 import com.dekk.app.user.domain.repository.UserRepository;
+import com.dekk.global.event.UserDeletedEvent;
 
 import java.util.Optional;
 
@@ -18,6 +19,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 
 @ExtendWith(MockitoExtension.class)
 class UserCommandServiceTest {
@@ -29,10 +31,13 @@ class UserCommandServiceTest {
     private UserRepository userRepository;
 
     @Mock
-    private DeckWithdrawalCommandService deckWithdrawalCommandService;
+    private ProfileRepository profileRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @Test
-    @DisplayName("유저 탈퇴 시 덱 연관 데이터를 먼저 정리한 후 유저 상태를 DELETED로 변경한다")
+    @DisplayName("유저 탈퇴 시 연관 데이터를 정리하는 글로벌 이벤트를 발행한 후 유저 상태를 DELETED로 변경한다")
     void deleteUser_success() {
         Long userId = 1L;
         User user = mock(User.class);
@@ -41,8 +46,7 @@ class UserCommandServiceTest {
 
         userCommandService.deleteUser(userId);
 
-        verify(deckWithdrawalCommandService).processWithdrawal(userId);
-
+        verify(eventPublisher).publishEvent(any(UserDeletedEvent.class));
         verify(user).deleteUser();
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> # [DK-434](https://potenup-final.atlassian.net/browse/DK-434)

## 📝작업 내용

> 이번 PR에서는 User와 Deck 도메인 간의 강결합을 해소하고, 소셜 로그인 시 동일 이메일 가입을 허용하는 핵심 아키텍처 및 정책 변경을 진행했습니다.

- **User ↔ Deck 도메인 이벤트 디커플링**
  - `UserCommandService` 내부의 Deck 관련 직접 의존성을 전면 제거하고, `ApplicationEventPublisher`를 도입했습니다.
  - 신규 가입 시 `UserOnboardedEvent`, 회원 탈퇴 시 `UserDeletedEvent`를 발행하여, Deck 도메인(`UserEventHandler`)이 이를 구독하여 보관함 자동 생성 및 연쇄 Soft Delete를 처리하도록 구조를 개선했습니다.
- **동일 이메일 계정 정책 변경 (복합 유니크 키 적용)**
  - 구글/카카오 등 소셜 제공자가 다르면 동일한 이메일이어도 각각 독립된 계정으로 가입되도록 비즈니스 정책을 변경했습니다.
  - `User` 엔티티의 `email` 단일 유니크 제약조건(`unique=true`)을 해제하고, `email + provider` 복합 유니크 키 제약조건을 명시했습니다. (※ DB 물리 스키마 반영용 Flyway 스크립트는 사전 머지 완료)
- **잠재적 장애 요인(500 에러) 완벽 차단 및 레거시 청산**
  - 중복 이메일 허용에 따라 `NonUniqueResultException` 발생 위험이 있는 레포지토리 계층의 `findByEmail` 단건 조회 메서드를 전면 파기했습니다.
  - 사용하지 않게 된 `DUPLICATE_EMAIL` 보안 에러코드를 정리하고, `CustomOAuth2UserService` 내부의 이메일 중복 예외 처리 로직을 제거하여 신규 정책에 맞게 수정했습니다.
- **N+1 쿼리 성능 최적화**
  - `User` 엔티티의 `Profile` 연관관계(@OneToOne)에 숨어있던 EAGER 로딩을 `FetchType.LAZY`로 명시적 교정하여 무의미한 조인 쿼리 폭주를 방어했습니다.

### 스크린샷 (선택)
#### 1. 동일 이메일, 다른 소셜 계정 독립 생성 검증 (V2 스키마)
> 기존 500 에러 없이 카카오/구글 계정이 각각 분리되어 평화롭게 공존하는 것을 확인했습니다.

<img width="1512" height="982" alt="이메일이 같더라도 다른 provider라면 회원가입가능" src="https://github.com/user-attachments/assets/cd3275f4-21c8-4c31-a9b3-edddd9db95ec" />


#### 2. 이벤트 기반 기본 보관함 자동 생성 (UserOnboardedEvent)
> User 도메인이 Deck을 몰라도, 온보딩 완료 시 이벤트 리스너를 통해 기본 덱이 정상 생성됩니다.

<img width="751" height="826" alt="유저온보딩" src="https://github.com/user-attachments/assets/06b065fb-29e1-4f60-9982-e47af9e26793" />
<img width="751" height="739" alt="기본덱 생성 확인" src="https://github.com/user-attachments/assets/561c5ae8-f041-41f5-9763-5c631032fcb9" />


#### 3. 이벤트 기반 연쇄 회원 탈퇴 (UserDeletedEvent)
> 회원 탈퇴 시 이벤트가 발행되어 유저 상태, 소유한 덱(기본/커스텀), 매핑된 멤버 권한이 한 번에 Soft Delete 처리됩니다.

<img width="731" height="721" alt="커스텀덱 생성" src="https://github.com/user-attachments/assets/9e168019-c540-4dec-afcf-fecfee6edfae" />

<img width="731" height="485" alt="회원탈퇴" src="https://github.com/user-attachments/assets/0ee18b9a-e4e3-4a4b-92a3-8ef6a7a8f16b" />

<img width="1512" height="982" alt="회원탈퇴시 유저 상태 변경 DELETE 확인" src="https://github.com/user-attachments/assets/4dcfda04-bbaf-4b64-a194-c93e275ddf45" />

<img width="1512" height="982" alt="회원 탈퇴시 기본덱과 테테스트덱 모두 삭제됨" src="https://github.com/user-attachments/assets/16b1998a-90a0-43a8-9e70-702d9e555934" />

<img width="1512" height="982" alt="내 유저 ID로 매핑된 권한 row들 삭제확인" src="https://github.com/user-attachments/assets/19fe3661-fd52-43ff-893f-c060b195dbf2" />

## 💬리뷰 요구사항(선택)

> - `UserCommandService`에서 Deck 관련 코드가 완전히 제거되고 도메인 이벤트(`UserOnboardedEvent`, `UserDeletedEvent`)로 깔끔하게 디커플링된 구조를 중점적으로 확인해 주시면 감사하겠습니다.
> - `UserRepository`에서 `findByEmail`이 사라짐에 따라 `CustomOAuth2UserService` 로직이 일부 수정되었습니다. 
>   **(※ 참고: 해당 OAuth2 서비스 및 인증 인프라는 다음 태스크인 `[DK-436]` , `[DK-438]`에서 외부 API 트랜잭션 분리 및 글로벌 패키지로 대규모 리팩토링이 예정되어 있습니다. 본 PR에서는 컴파일 및 기능 유지를 위한 최소한의 변경만 적용되었습니다.)**

[DK-434]: https://potenup-final.atlassian.net/browse/DK-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DK-436]: https://potenup-final.atlassian.net/browse/DK-436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ