### PR TITLE
[REFACTOR] Argument Resolver 도입 및 컨트롤러 디커플링 (#DK-440)

### DIFF
--- a/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogApi.java
+++ b/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogApi.java
@@ -3,7 +3,7 @@ package com.dekk.app.activelog.presentation.controller;
 import com.dekk.app.activelog.domain.exception.ActiveLogErrorCode;
 import com.dekk.app.activelog.presentation.request.SwipeRequest;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -21,5 +21,5 @@ public interface ActiveLogApi {
     ResponseEntity<ApiResponse<Void>> swipeCard(
             @Parameter(description = "대상 카드 ID", in = ParameterIn.PATH) Long cardId,
             @RequestBody(description = "스와이프 요청 정보(LIKE/DISLIKE)") SwipeRequest request,
-            @Parameter(hidden = true) CustomUserDetails userDetails);
+            @LoginUser Long userId);
 }

--- a/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogController.java
+++ b/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogController.java
@@ -5,11 +5,10 @@ import com.dekk.app.activelog.application.dto.command.SwipeCommand;
 import com.dekk.app.activelog.presentation.request.SwipeRequest;
 import com.dekk.app.activelog.presentation.response.ActiveLogResultCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,11 +23,9 @@ public class ActiveLogController implements ActiveLogApi {
     @Override
     @PostMapping("/w/v1/cards/{cardId}/swipe")
     public ResponseEntity<ApiResponse<Void>> swipeCard(
-            @PathVariable("cardId") Long cardId,
-            @Valid @RequestBody SwipeRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+            @PathVariable("cardId") Long cardId, @Valid @RequestBody SwipeRequest request, @LoginUser Long userId) {
 
-        SwipeCommand command = new SwipeCommand(userDetails.getId(), cardId, request.swipeType());
+        SwipeCommand command = new SwipeCommand(userId, cardId, request.swipeType());
         activeLogCommandService.saveSwipeAction(command);
 
         return ResponseEntity.ok(ApiResponse.from(ActiveLogResultCode.SWIPE_SUCCESS));

--- a/src/main/java/com/dekk/app/admin/presentation/controller/AdminInspectionApi.java
+++ b/src/main/java/com/dekk/app/admin/presentation/controller/AdminInspectionApi.java
@@ -4,9 +4,9 @@ import com.dekk.app.admin.domain.exception.AdminErrorCode;
 import com.dekk.app.admin.domain.model.InspectionStatus;
 import com.dekk.app.admin.presentation.request.InspectionStatusUpdateRequest;
 import com.dekk.app.admin.presentation.response.ImageInspectionResponse;
-import com.dekk.app.admin.security.AdminUserDetails;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
+import com.dekk.global.security.annotation.LoginAdmin;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -15,7 +15,6 @@ import jakarta.validation.Valid;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -35,5 +34,5 @@ public interface AdminInspectionApi {
     ResponseEntity<ApiResponse<Void>> updateInspectionStatus(
             @Parameter(description = "검수 ID") @PathVariable Long inspectionId,
             @Valid @RequestBody InspectionStatusUpdateRequest request,
-            @Parameter(hidden = true) @AuthenticationPrincipal AdminUserDetails adminUserDetails);
+            @LoginAdmin Long adminId);
 }

--- a/src/main/java/com/dekk/app/admin/presentation/controller/AdminInspectionController.java
+++ b/src/main/java/com/dekk/app/admin/presentation/controller/AdminInspectionController.java
@@ -6,15 +6,14 @@ import com.dekk.app.admin.domain.model.InspectionStatus;
 import com.dekk.app.admin.presentation.request.InspectionStatusUpdateRequest;
 import com.dekk.app.admin.presentation.response.AdminResultCode;
 import com.dekk.app.admin.presentation.response.ImageInspectionResponse;
-import com.dekk.app.admin.security.AdminUserDetails;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
+import com.dekk.global.security.annotation.LoginAdmin;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -44,9 +43,9 @@ public class AdminInspectionController implements AdminInspectionApi {
     public ResponseEntity<ApiResponse<Void>> updateInspectionStatus(
             @PathVariable Long inspectionId,
             @Valid @RequestBody InspectionStatusUpdateRequest request,
-            @AuthenticationPrincipal AdminUserDetails adminUserDetails) {
+            @LoginAdmin Long adminId) {
 
-        commandService.updateInspectionStatus(request.toCommand(inspectionId, adminUserDetails.adminId()));
+        commandService.updateInspectionStatus(request.toCommand(inspectionId, adminId));
 
         return ResponseEntity.ok(ApiResponse.from(AdminResultCode.INSPECTION_STATUS_UPDATED));
     }

--- a/src/main/java/com/dekk/app/card/presentation/controller/CardCommandApi.java
+++ b/src/main/java/com/dekk/app/card/presentation/controller/CardCommandApi.java
@@ -1,10 +1,10 @@
 package com.dekk.app.card.presentation.controller;
 
-import com.dekk.app.admin.security.AdminUserDetails;
 import com.dekk.app.card.domain.exception.CardErrorCode;
 import com.dekk.app.card.presentation.request.AssignCategoriesRequest;
 import com.dekk.app.card.presentation.request.RequestDeleteCardRequest;
 import com.dekk.global.response.ApiResponse;
+import com.dekk.global.security.annotation.LoginAdmin;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -115,5 +115,5 @@ public interface CardCommandApi {
     ResponseEntity<ApiResponse<Void>> requestDeleteCard(
             @Parameter(description = "삭제 요청할 카드 ID", in = ParameterIn.PATH) Long cardId,
             RequestDeleteCardRequest request,
-            @Parameter(hidden = true) AdminUserDetails adminUserDetails);
+            @LoginAdmin Long adminId);
 }

--- a/src/main/java/com/dekk/app/card/presentation/controller/CardCommandController.java
+++ b/src/main/java/com/dekk/app/card/presentation/controller/CardCommandController.java
@@ -1,15 +1,14 @@
 package com.dekk.app.card.presentation.controller;
 
-import com.dekk.app.admin.security.AdminUserDetails;
 import com.dekk.app.card.application.CardCommandService;
 import com.dekk.app.card.presentation.request.AssignCategoriesRequest;
 import com.dekk.app.card.presentation.request.RequestDeleteCardRequest;
 import com.dekk.app.card.presentation.response.CardResultCode;
 import com.dekk.global.response.ApiResponse;
+import com.dekk.global.security.annotation.LoginAdmin;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -51,8 +50,8 @@ public class CardCommandController implements CardCommandApi {
     public ResponseEntity<ApiResponse<Void>> requestDeleteCard(
             @PathVariable("cardId") Long cardId,
             @Valid @RequestBody RequestDeleteCardRequest request,
-            @AuthenticationPrincipal AdminUserDetails adminUserDetails) {
-        cardCommandService.requestDeleteCard(request.toCommand(cardId, adminUserDetails.adminId()));
+            @LoginAdmin Long adminId) {
+        cardCommandService.requestDeleteCard(request.toCommand(cardId, adminId));
         return ResponseEntity.ok(ApiResponse.from(CardResultCode.CARD_DELETE_REQUEST_SUCCESS));
     }
 }

--- a/src/main/java/com/dekk/app/card/presentation/controller/CardQueryApi.java
+++ b/src/main/java/com/dekk/app/card/presentation/controller/CardQueryApi.java
@@ -4,7 +4,7 @@ import com.dekk.app.card.presentation.response.GuestCardResponse;
 import com.dekk.app.card.presentation.response.MemberCardResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -14,7 +14,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "카드 조회 API", description = "카드 조회 관련 API")
@@ -90,7 +89,7 @@ public interface CardQueryApi {
                                         }))
             })
     ResponseEntity<ApiResponse<PageResponse<?>>> getCards(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @Parameter(description = "페이지 번호 (0부터 시작)", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기", example = "10") @RequestParam(defaultValue = "10") int size);
 }

--- a/src/main/java/com/dekk/app/card/presentation/controller/CardQueryController.java
+++ b/src/main/java/com/dekk/app/card/presentation/controller/CardQueryController.java
@@ -6,12 +6,11 @@ import com.dekk.app.card.presentation.response.GuestCardResponse;
 import com.dekk.app.card.presentation.response.MemberCardResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -27,12 +26,12 @@ public class CardQueryController implements CardQueryApi {
     @Override
     @GetMapping
     public ResponseEntity<ApiResponse<PageResponse<?>>> getCards(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size) {
         Pageable pageable = PageRequest.of(page, size);
 
-        if (userDetails != null) {
+        if (userId != null) {
             return ResponseEntity.ok(ApiResponse.of(CardResultCode.MEMBER_CARD_LIST_SUCCESS, getMemberCards(pageable)));
         }
         return ResponseEntity.ok(ApiResponse.of(CardResultCode.GUEST_CARD_LIST_SUCCESS, getGuestCards(pageable)));

--- a/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryApi.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryApi.java
@@ -3,7 +3,7 @@ package com.dekk.app.card.recommend.presentation.controller;
 import com.dekk.app.card.recommend.presentation.dto.response.RecommendCardResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.SliceResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -13,7 +13,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import java.util.UUID;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "추천 카드 조회 API", description = "사용자 맞춤형 추천 카드 조회 API")
@@ -28,7 +27,7 @@ public interface RecommendQueryApi {
                         content = @Content(schema = @Schema(implementation = RecommendCardResponse.class)))
             })
     ResponseEntity<ApiResponse<SliceResponse<RecommendCardResponse>>> getRecommendCards(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @Parameter(description = "페이지 번호", example = "0") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 당 카드 수 (최대 50)", example = "10") @RequestParam(defaultValue = "10") @Max(50)
                     int size,

--- a/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryController.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/controller/RecommendQueryController.java
@@ -5,14 +5,13 @@ import com.dekk.app.card.recommend.presentation.dto.response.RecommendCardRespon
 import com.dekk.app.card.recommend.presentation.response.RecommendResultCode;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.SliceResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -28,14 +27,14 @@ public class RecommendQueryController implements RecommendQueryApi {
     @Override
     @GetMapping
     public ResponseEntity<ApiResponse<SliceResponse<RecommendCardResponse>>> getRecommendCards(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(required = false) UUID startCardId) {
         Pageable pageable = PageRequest.of(page, size);
 
         Slice<RecommendCardResponse> result = recommendQueryService
-                .getRecommendCards(userDetails.getId(), pageable, startCardId)
+                .getRecommendCards(userId, pageable, startCardId)
                 .map(RecommendCardResponse::from);
 
         return ResponseEntity.ok(

--- a/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckCommandApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckCommandApi.java
@@ -4,7 +4,7 @@ import com.dekk.app.deck.domain.exception.DeckErrorCode;
 import com.dekk.app.deck.presentation.request.CustomDeckCreateRequest;
 import com.dekk.app.deck.presentation.request.CustomDeckUpdateRequest;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -20,14 +20,13 @@ public interface CustomDeckCommandApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20005)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> createCustomDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @RequestBody(description = "생성할 커스텀덱 정보") CustomDeckCreateRequest request);
+            @LoginUser Long userId, @RequestBody(description = "생성할 커스텀덱 정보") CustomDeckCreateRequest request);
 
     @Operation(summary = "커스텀덱 이름 수정", description = "커스텀덱의 이름을 수정합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20006)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> updateCustomDeckName(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @Parameter(description = "수정할 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId,
             @RequestBody(description = "수정할 덱 이름 정보") CustomDeckUpdateRequest request);
 
@@ -35,14 +34,14 @@ public interface CustomDeckCommandApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20007)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> deleteCustomDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @Parameter(description = "삭제할 커스텀 보관함 ID", in = ParameterIn.PATH) Long customDeckId);
 
     @Operation(summary = "커스텀덱에 카드 저장", description = "커스텀덱에 특정 카드를 저장합니다. (최대 50장)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20009)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> saveCardToCustomDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @Parameter(description = "저장할 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId,
             @Parameter(description = "저장할 카드 ID", in = ParameterIn.PATH) Long cardId);
 
@@ -50,7 +49,7 @@ public interface CustomDeckCommandApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20010)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> removeCardFromCustomDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @Parameter(description = "커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId,
             @Parameter(description = "삭제할 카드 ID", in = ParameterIn.PATH) Long cardId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckCommandController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckCommandController.java
@@ -6,11 +6,10 @@ import com.dekk.app.deck.presentation.request.CustomDeckCreateRequest;
 import com.dekk.app.deck.presentation.request.CustomDeckUpdateRequest;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,9 +29,8 @@ public class CustomDeckCommandController implements CustomDeckCommandApi {
     @Override
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createCustomDeck(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody CustomDeckCreateRequest request) {
-        customDeckCommandService.createCustomDeck(userDetails.getId(), request.toCommand());
+            @LoginUser Long userId, @Valid @RequestBody CustomDeckCreateRequest request) {
+        customDeckCommandService.createCustomDeck(userId, request.toCommand());
 
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.CUSTOM_DECK_CREATE_SUCCESS));
     }
@@ -40,10 +38,10 @@ public class CustomDeckCommandController implements CustomDeckCommandApi {
     @Override
     @PatchMapping("/{customDeckId}")
     public ResponseEntity<ApiResponse<Void>> updateCustomDeckName(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @PathVariable("customDeckId") Long customDeckId,
             @Valid @RequestBody CustomDeckUpdateRequest request) {
-        customDeckCommandService.updateCustomDeckName(userDetails.getId(), customDeckId, request.toCommand());
+        customDeckCommandService.updateCustomDeckName(userId, customDeckId, request.toCommand());
 
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.CUSTOM_DECK_UPDATE_SUCCESS));
     }
@@ -51,8 +49,8 @@ public class CustomDeckCommandController implements CustomDeckCommandApi {
     @Override
     @DeleteMapping("/{customDeckId}")
     public ResponseEntity<ApiResponse<Void>> deleteCustomDeck(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable("customDeckId") Long customDeckId) {
-        customDeckCommandService.deleteCustomDeck(userDetails.getId(), customDeckId);
+            @LoginUser Long userId, @PathVariable("customDeckId") Long customDeckId) {
+        customDeckCommandService.deleteCustomDeck(userId, customDeckId);
 
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.CUSTOM_DECK_DELETE_SUCCESS));
     }
@@ -60,20 +58,20 @@ public class CustomDeckCommandController implements CustomDeckCommandApi {
     @Override
     @PostMapping("/{customDeckId}/cards/{cardId}")
     public ResponseEntity<ApiResponse<Void>> saveCardToCustomDeck(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @PathVariable("customDeckId") Long customDeckId,
             @PathVariable("cardId") Long cardId) {
-        deckCardCommandService.saveToCustomDeck(userDetails.getId(), customDeckId, cardId);
+        deckCardCommandService.saveToCustomDeck(userId, customDeckId, cardId);
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.CUSTOM_DECK_CARD_SAVE_SUCCESS));
     }
 
     @Override
     @DeleteMapping("/{customDeckId}/cards/{cardId}")
     public ResponseEntity<ApiResponse<Void>> removeCardFromCustomDeck(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @PathVariable("customDeckId") Long customDeckId,
             @PathVariable("cardId") Long cardId) {
-        deckCardCommandService.removeFromCustomDeck(userDetails.getId(), customDeckId, cardId);
+        deckCardCommandService.removeFromCustomDeck(userId, customDeckId, cardId);
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.CUSTOM_DECK_CARD_DELETE_SUCCESS));
     }
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryApi.java
@@ -4,7 +4,7 @@ import com.dekk.app.deck.domain.exception.DeckErrorCode;
 import com.dekk.app.deck.presentation.response.CustomDeckCardsResponse;
 import com.dekk.app.deck.presentation.response.CustomDeckResponse;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,8 +19,7 @@ public interface CustomDeckQueryApi {
     @Operation(summary = "내 커스텀덱(쉐어덱) 목록 조회", description = "사용자가 생성한 커스텀덱 목록과 최신 카드 썸네일(imageUrl) 1장을 최신순으로 조회합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20008)")
     @ApiErrorExceptions({DeckErrorCode.class})
-    ResponseEntity<ApiResponse<List<CustomDeckResponse>>> getMyCustomDecks(
-            @Parameter(hidden = true) CustomUserDetails userDetails);
+    ResponseEntity<ApiResponse<List<CustomDeckResponse>>> getMyCustomDecks(@LoginUser Long userId);
 
     @Operation(
             summary = "커스텀덱(쉐어덱) 내부 카드 목록 조회",
@@ -29,6 +28,5 @@ public interface CustomDeckQueryApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20011)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<CustomDeckCardsResponse>> getCustomDeckCards(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "조회할 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
+            @LoginUser Long userId, @Parameter(description = "조회할 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/CustomDeckQueryController.java
@@ -6,11 +6,10 @@ import com.dekk.app.deck.presentation.response.CustomDeckCardsResponse;
 import com.dekk.app.deck.presentation.response.CustomDeckResponse;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,10 +24,9 @@ public class CustomDeckQueryController implements CustomDeckQueryApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse<List<CustomDeckResponse>>> getMyCustomDecks(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponse<List<CustomDeckResponse>>> getMyCustomDecks(@LoginUser Long userId) {
 
-        List<CustomDeckResponse> response = customDeckQueryService.getMyCustomDecks(userDetails.getId()).stream()
+        List<CustomDeckResponse> response = customDeckQueryService.getMyCustomDecks(userId).stream()
                 .map(CustomDeckResponse::from)
                 .toList();
 
@@ -38,9 +36,9 @@ public class CustomDeckQueryController implements CustomDeckQueryApi {
     @Override
     @GetMapping("/{customDeckId}/cards")
     public ResponseEntity<ApiResponse<CustomDeckCardsResponse>> getCustomDeckCards(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable("customDeckId") Long customDeckId) {
+            @LoginUser Long userId, @PathVariable("customDeckId") Long customDeckId) {
 
-        CustomDeckCardsResult result = customDeckQueryService.getCustomDeckCards(userDetails.getId(), customDeckId);
+        CustomDeckCardsResult result = customDeckQueryService.getCustomDeckCards(userId, customDeckId);
 
         return ResponseEntity.ok(
                 ApiResponse.of(DeckResultCode.CUSTOM_DECK_CARD_LIST_SUCCESS, CustomDeckCardsResponse.from(result)));

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DeckQueryApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DeckQueryApi.java
@@ -3,10 +3,9 @@ package com.dekk.app.deck.presentation.controller;
 import com.dekk.app.deck.domain.exception.DeckErrorCode;
 import com.dekk.app.deck.presentation.response.DeckResponse;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -19,5 +18,5 @@ public interface DeckQueryApi {
             description = "사용자가 참여 중인 모든 덱(기본덱, 커스텀덱, 쉐어덱)을 통합 조회합니다. 기본덱이 최상단에 위치하며, 각 덱의 최신 카드 썸네일(최대 3장)을 포함합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SD20012: 보관함 통합 목록 조회 성공")
     @ApiErrorExceptions({DeckErrorCode.class})
-    ResponseEntity<ApiResponse<List<DeckResponse>>> getDecks(@Parameter(hidden = true) CustomUserDetails userDetails);
+    ResponseEntity<ApiResponse<List<DeckResponse>>> getDecks(@LoginUser Long userId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DeckQueryController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DeckQueryController.java
@@ -4,11 +4,10 @@ import com.dekk.app.deck.application.DeckQueryService;
 import com.dekk.app.deck.presentation.response.DeckResponse;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,10 +21,9 @@ public class DeckQueryController implements DeckQueryApi {
 
     @Override
     @GetMapping
-    public ResponseEntity<ApiResponse<List<DeckResponse>>> getDecks(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ApiResponse<List<DeckResponse>>> getDecks(@LoginUser Long userId) {
 
-        List<DeckResponse> response = deckQueryService.getDecks(userDetails.getId()).stream()
+        List<DeckResponse> response = deckQueryService.getDecks(userId).stream()
                 .map(DeckResponse::from)
                 .toList();
 

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckCommandApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckCommandApi.java
@@ -2,7 +2,7 @@ package com.dekk.app.deck.presentation.controller;
 
 import com.dekk.app.deck.domain.exception.DeckErrorCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,6 +17,5 @@ public interface DefaultDeckCommandApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SD20004: 덱 내 카드 저장 취소 성공")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> removeCardFromDefaultDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "삭제할 카드 ID", in = ParameterIn.PATH) Long cardId);
+            @LoginUser Long userId, @Parameter(description = "삭제할 카드 ID", in = ParameterIn.PATH) Long cardId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckCommandController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckCommandController.java
@@ -4,10 +4,9 @@ import com.dekk.app.deck.application.DeckCardCommandService;
 import com.dekk.app.deck.application.DefaultDeckCommandService;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,8 +23,8 @@ public class DefaultDeckCommandController implements DefaultDeckCommandApi {
     @Override
     @DeleteMapping("/cards/{cardId}")
     public ResponseEntity<ApiResponse<Void>> removeCardFromDefaultDeck(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable("cardId") Long cardId) {
-        deckCardCommandService.removeFromDefaultDeck(userDetails.getId(), cardId);
+            @LoginUser Long userId, @PathVariable("cardId") Long cardId) {
+        deckCardCommandService.removeFromDefaultDeck(userId, cardId);
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.DECK_CARD_DELETED_SUCCESS));
     }
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckQueryApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckQueryApi.java
@@ -4,10 +4,9 @@ import com.dekk.app.deck.domain.exception.DeckErrorCode;
 import com.dekk.app.deck.presentation.response.MyDeckCardResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Pageable;
@@ -20,5 +19,5 @@ public interface DefaultDeckQueryApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SDK20002)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<PageResponse<MyDeckCardResponse>>> getMyDefaultDeckCards(
-            @Parameter(hidden = true) CustomUserDetails userDetails, @ParameterObject Pageable pageable);
+            @LoginUser Long userId, @ParameterObject Pageable pageable);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckQueryController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/DefaultDeckQueryController.java
@@ -5,7 +5,7 @@ import com.dekk.app.deck.presentation.response.DeckResultCode;
 import com.dekk.app.deck.presentation.response.MyDeckCardResponse;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.response.PageResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.data.domain.Page;
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,12 +27,11 @@ public class DefaultDeckQueryController implements DefaultDeckQueryApi {
     @Override
     @GetMapping("/cards")
     public ResponseEntity<ApiResponse<PageResponse<MyDeckCardResponse>>> getMyDefaultDeckCards(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @LoginUser Long userId,
             @ParameterObject @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
 
-        Page<MyDeckCardResponse> responsePage = deckQueryService
-                .getMyDefaultDeckCards(userDetails.getId(), pageable)
-                .map(MyDeckCardResponse::from);
+        Page<MyDeckCardResponse> responsePage =
+                deckQueryService.getMyDefaultDeckCards(userId, pageable).map(MyDeckCardResponse::from);
 
         return ResponseEntity.ok(
                 ApiResponse.of(DeckResultCode.DECK_CARD_LIST_SUCCESS, PageResponse.from(responsePage)));

--- a/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandApi.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandApi.java
@@ -4,7 +4,7 @@ import com.dekk.app.deck.domain.exception.DeckErrorCode;
 import com.dekk.app.deck.presentation.request.SharedDeckJoinRequest;
 import com.dekk.app.deck.presentation.response.ShareTokenResponse;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -23,8 +23,7 @@ public interface ShareDeckCommandApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20013)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<ShareTokenResponse>> turnOnShare(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "공유를 켤 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
+            @LoginUser Long userId, @Parameter(description = "공유를 켤 커스텀덱 ID", in = ParameterIn.PATH) Long customDeckId);
 
     @Operation(
             summary = "쉐어덱 공유 끄기 (호스트 전용)",
@@ -32,8 +31,7 @@ public interface ShareDeckCommandApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20014)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> turnOffShare(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "공유를 끌 쉐어덱 ID", in = ParameterIn.PATH) Long customDeckId);
+            @LoginUser Long userId, @Parameter(description = "공유를 끌 쉐어덱 ID", in = ParameterIn.PATH) Long customDeckId);
 
     @Operation(
             summary = "초대 링크로 쉐어덱 참여 (게스트 전용)",
@@ -41,8 +39,7 @@ public interface ShareDeckCommandApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20015)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> joinSharedDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @RequestBody(description = "참여용 토큰 정보") SharedDeckJoinRequest request);
+            @LoginUser Long userId, @RequestBody(description = "참여용 토큰 정보") SharedDeckJoinRequest request);
 
     @Operation(
             summary = "쉐어덱 자진 퇴장 (게스트 전용)",
@@ -51,6 +48,5 @@ public interface ShareDeckCommandApi {
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SD20016)")
     @ApiErrorExceptions({DeckErrorCode.class})
     ResponseEntity<ApiResponse<Void>> leaveSharedDeck(
-            @Parameter(hidden = true) CustomUserDetails userDetails,
-            @Parameter(description = "퇴장할 쉐어덱 ID", in = ParameterIn.PATH) Long sharedDeckId);
+            @LoginUser Long userId, @Parameter(description = "퇴장할 쉐어덱 ID", in = ParameterIn.PATH) Long sharedDeckId);
 }

--- a/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandController.java
+++ b/src/main/java/com/dekk/app/deck/presentation/controller/ShareDeckCommandController.java
@@ -6,11 +6,10 @@ import com.dekk.app.deck.presentation.request.SharedDeckJoinRequest;
 import com.dekk.app.deck.presentation.response.DeckResultCode;
 import com.dekk.app.deck.presentation.response.ShareTokenResponse;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -28,9 +27,9 @@ public class ShareDeckCommandController implements ShareDeckCommandApi {
     @Override
     @PostMapping("/custom/{customDeckId}/share")
     public ResponseEntity<ApiResponse<ShareTokenResponse>> turnOnShare(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable("customDeckId") Long customDeckId) {
+            @LoginUser Long userId, @PathVariable("customDeckId") Long customDeckId) {
 
-        ShareTokenResult result = shareDeckCommandService.turnOnShareAndGetToken(userDetails.getId(), customDeckId);
+        ShareTokenResult result = shareDeckCommandService.turnOnShareAndGetToken(userId, customDeckId);
 
         return ResponseEntity.ok(ApiResponse.of(DeckResultCode.SHARE_DECK_ON_SUCCESS, ShareTokenResponse.from(result)));
     }
@@ -38,24 +37,24 @@ public class ShareDeckCommandController implements ShareDeckCommandApi {
     @Override
     @DeleteMapping("/custom/{customDeckId}/share")
     public ResponseEntity<ApiResponse<Void>> turnOffShare(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable("customDeckId") Long customDeckId) {
-        shareDeckCommandService.turnOffShare(userDetails.getId(), customDeckId);
+            @LoginUser Long userId, @PathVariable("customDeckId") Long customDeckId) {
+        shareDeckCommandService.turnOffShare(userId, customDeckId);
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.SHARE_DECK_OFF_SUCCESS));
     }
 
     @Override
     @PostMapping("/shared/join")
     public ResponseEntity<ApiResponse<Void>> joinSharedDeck(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody SharedDeckJoinRequest request) {
-        shareDeckCommandService.joinSharedDeck(userDetails.getId(), request.token());
+            @LoginUser Long userId, @Valid @RequestBody SharedDeckJoinRequest request) {
+        shareDeckCommandService.joinSharedDeck(userId, request.token());
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.SHARE_DECK_JOIN_SUCCESS));
     }
 
     @Override
     @DeleteMapping("/shared/{sharedDeckId}/leave")
     public ResponseEntity<ApiResponse<Void>> leaveSharedDeck(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @PathVariable("sharedDeckId") Long sharedDeckId) {
-        shareDeckCommandService.leaveSharedDeck(userDetails.getId(), sharedDeckId);
+            @LoginUser Long userId, @PathVariable("sharedDeckId") Long sharedDeckId) {
+        shareDeckCommandService.leaveSharedDeck(userId, sharedDeckId);
         return ResponseEntity.ok(ApiResponse.from(DeckResultCode.SHARE_DECK_LEAVE_SUCCESS));
     }
 }

--- a/src/main/java/com/dekk/app/user/presentation/controller/UserCommandApi.java
+++ b/src/main/java/com/dekk/app/user/presentation/controller/UserCommandApi.java
@@ -4,16 +4,14 @@ import com.dekk.app.user.presentation.request.UserOnboardingRequest;
 import com.dekk.app.user.presentation.request.UserProfileUpdateRequest;
 import com.dekk.global.error.ErrorResponse;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "사용자 정보 관리 API", description = "사용자 정보 및 상태 변경 API")
@@ -39,8 +37,7 @@ public interface UserCommandApi {
                         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     ResponseEntity<ApiResponse<Void>> onboardUser(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody UserOnboardingRequest request);
+            @LoginUser Long userId, @Valid @RequestBody UserOnboardingRequest request);
 
     @Operation(summary = "프로필 업데이트", description = "닉네임, 키, 몸무게 등 사용자의 프로필 정보를 업데이트합니다.")
     @ApiResponses(
@@ -58,8 +55,7 @@ public interface UserCommandApi {
                         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
     ResponseEntity<ApiResponse<Void>> updateProfile(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody UserProfileUpdateRequest request);
+            @LoginUser Long userId, @Valid @RequestBody UserProfileUpdateRequest request);
 
     @Operation(summary = "회원 탈퇴", description = "사용자 계정을 삭제하여 회원 탈퇴를 진행합니다.")
     @ApiResponses(
@@ -72,6 +68,5 @@ public interface UserCommandApi {
                         description = "사용자를 찾을 수 없음(EU40401)",
                         content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
             })
-    ResponseEntity<ApiResponse<Void>> deleteUser(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+    ResponseEntity<ApiResponse<Void>> deleteUser(@LoginUser Long userId);
 }

--- a/src/main/java/com/dekk/app/user/presentation/controller/UserCommandController.java
+++ b/src/main/java/com/dekk/app/user/presentation/controller/UserCommandController.java
@@ -5,11 +5,10 @@ import com.dekk.app.user.presentation.request.UserOnboardingRequest;
 import com.dekk.app.user.presentation.request.UserProfileUpdateRequest;
 import com.dekk.app.user.presentation.response.UserResultCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -27,8 +26,8 @@ public class UserCommandController implements UserCommandApi {
     @Override
     @PostMapping("/onboarding")
     public ResponseEntity<ApiResponse<Void>> onboardUser(
-            @AuthenticationPrincipal CustomUserDetails userDetails, @Valid @RequestBody UserOnboardingRequest request) {
-        userCommandService.onboardUser(userDetails.getId(), request.toCommand());
+            @LoginUser Long userId, @Valid @RequestBody UserOnboardingRequest request) {
+        userCommandService.onboardUser(userId, request.toCommand());
 
         return ResponseEntity.ok(ApiResponse.from(UserResultCode.ONBOARDING_SUCCESS));
     }
@@ -36,17 +35,16 @@ public class UserCommandController implements UserCommandApi {
     @Override
     @PatchMapping("/me")
     public ResponseEntity<ApiResponse<Void>> updateProfile(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
-            @Valid @RequestBody UserProfileUpdateRequest request) {
-        userCommandService.updateProfileInfo(userDetails.getId(), request.toCommand());
+            @LoginUser Long userId, @Valid @RequestBody UserProfileUpdateRequest request) {
+        userCommandService.updateProfileInfo(userId, request.toCommand());
 
         return ResponseEntity.ok(ApiResponse.from(UserResultCode.PROFILE_UPDATE_SUCCESS));
     }
 
     @Override
     @DeleteMapping("/me")
-    public ResponseEntity<ApiResponse<Void>> deleteUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
-        userCommandService.deleteUser(userDetails.getId());
+    public ResponseEntity<ApiResponse<Void>> deleteUser(@LoginUser Long userId) {
+        userCommandService.deleteUser(userId);
 
         return ResponseEntity.ok(ApiResponse.from(UserResultCode.USER_DELETE_SUCCESS));
     }

--- a/src/main/java/com/dekk/app/user/presentation/controller/UserQueryApi.java
+++ b/src/main/java/com/dekk/app/user/presentation/controller/UserQueryApi.java
@@ -2,17 +2,14 @@ package com.dekk.app.user.presentation.controller;
 
 import com.dekk.app.user.presentation.response.UserInfoResponse;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
 @Tag(name = "사용자 정보 조회 API", description = "사용자 정보 조회 API")
 public interface UserQueryApi {
 
     @Operation(summary = "내 정보 조회", description = "현재 로그인된 사용자의 상세 프로필 정보를 조회합니다.")
-    ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(
-            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails);
+    ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(@LoginUser Long userId);
 }

--- a/src/main/java/com/dekk/app/user/presentation/controller/UserQueryController.java
+++ b/src/main/java/com/dekk/app/user/presentation/controller/UserQueryController.java
@@ -5,10 +5,9 @@ import com.dekk.app.user.application.dto.result.UserInfoResult;
 import com.dekk.app.user.presentation.response.UserInfoResponse;
 import com.dekk.app.user.presentation.response.UserResultCode;
 import com.dekk.global.response.ApiResponse;
-import com.dekk.global.security.oauth2.CustomUserDetails;
+import com.dekk.global.security.annotation.LoginUser;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,9 +21,8 @@ public class UserQueryController implements UserQueryApi {
 
     @Override
     @GetMapping("/me")
-    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(
-            @AuthenticationPrincipal CustomUserDetails userDetails) {
-        UserInfoResult result = userQueryService.getMyInfo(userDetails.getId());
+    public ResponseEntity<ApiResponse<UserInfoResponse>> getMyInfo(@LoginUser Long userId) {
+        UserInfoResult result = userQueryService.getMyInfo(userId);
         UserInfoResponse response = UserInfoResponse.from(result);
 
         return ResponseEntity.ok(ApiResponse.of(UserResultCode.GET_MY_INFO_SUCCESS, response));

--- a/src/main/java/com/dekk/global/config/WebMvcConfig.java
+++ b/src/main/java/com/dekk/global/config/WebMvcConfig.java
@@ -1,0 +1,23 @@
+package com.dekk.global.config;
+
+import com.dekk.global.security.resolver.LoginAdminArgumentResolver;
+import com.dekk.global.security.resolver.LoginUserArgumentResolver;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final LoginUserArgumentResolver loginUserArgumentResolver;
+    private final LoginAdminArgumentResolver loginAdminArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(loginUserArgumentResolver);
+        resolvers.add(loginAdminArgumentResolver);
+    }
+}

--- a/src/main/java/com/dekk/global/security/annotation/LoginAdmin.java
+++ b/src/main/java/com/dekk/global/security/annotation/LoginAdmin.java
@@ -1,0 +1,10 @@
+package com.dekk.global.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginAdmin {}

--- a/src/main/java/com/dekk/global/security/annotation/LoginUser.java
+++ b/src/main/java/com/dekk/global/security/annotation/LoginUser.java
@@ -1,0 +1,10 @@
+package com.dekk.global.security.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginUser {}

--- a/src/main/java/com/dekk/global/security/resolver/LoginAdminArgumentResolver.java
+++ b/src/main/java/com/dekk/global/security/resolver/LoginAdminArgumentResolver.java
@@ -1,0 +1,43 @@
+package com.dekk.global.security.resolver;
+
+import com.dekk.app.admin.security.AdminUserDetails;
+import com.dekk.global.security.annotation.LoginAdmin;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginAdminArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasLoginAdminAnnotation = parameter.hasParameterAnnotation(LoginAdmin.class);
+        boolean isLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+        return hasLoginAdminAnnotation && isLongType;
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof AdminUserDetails adminDetails) {
+            return adminDetails.adminId();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dekk/global/security/resolver/LoginUserArgumentResolver.java
+++ b/src/main/java/com/dekk/global/security/resolver/LoginUserArgumentResolver.java
@@ -1,0 +1,43 @@
+package com.dekk.global.security.resolver;
+
+import com.dekk.global.security.annotation.LoginUser;
+import com.dekk.global.security.oauth2.CustomUserDetails;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+public class LoginUserArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean hasLoginUserAnnotation = parameter.hasParameterAnnotation(LoginUser.class);
+        boolean isLongType = Long.class.isAssignableFrom(parameter.getParameterType());
+        return hasLoginUserAnnotation && isLongType;
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null
+                || !authentication.isAuthenticated()
+                || "anonymousUser".equals(authentication.getPrincipal())) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof CustomUserDetails userDetails) {
+            return userDetails.getId();
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/dekk/global/swagger/OpenApiConfig.java
+++ b/src/main/java/com/dekk/global/swagger/OpenApiConfig.java
@@ -1,15 +1,24 @@
 package com.dekk.global.swagger;
 
+import com.dekk.global.security.annotation.LoginAdmin;
+import com.dekk.global.security.annotation.LoginUser;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import jakarta.annotation.PostConstruct;
+import org.springdoc.core.utils.SpringDocUtils;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class OpenApiConfig {
+
+    @PostConstruct
+    public void init() {
+        SpringDocUtils.getConfig().addAnnotationsToIgnore(LoginUser.class, LoginAdmin.class);
+    }
 
     @Bean
     public OpenAPI openAPI() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> # [DK-440](https://potenup-final.atlassian.net/browse/DK-440)

## 📝작업 내용

> 이번 PR은 **프레임워크 기술(Spring Security)이 도메인 계층(Controller)으로 침투하는 것을 완벽히 차단**하는 클린 아키텍처 리팩토링 작업입니다. 기존 컨트롤러에 무겁게 결합되어 있던 시큐리티 인증 객체를 걷어내고, 순수한 식별자(Long)만 주입받도록 개선했습니다.

- **인프라: 커스텀 어노테이션 및 Argument Resolver 도입**
  - 컨트롤러 파라미터 주입용 `@LoginUser`, `@LoginAdmin` 어노테이션을 생성했습니다.
  - `SecurityContext`에서 `CustomUserDetails` / `AdminUserDetails`를 꺼내어 순수 식별자(`Long userId`, `Long adminId`)만 반환하는 `LoginUserArgumentResolver`, `LoginAdminArgumentResolver`를 구현하고 `WebMvcConfig`에 등록했습니다.
  - 비로그인 허용 API 접근 시 익명 사용자(`anonymousUser`)에 대해 안전하게 `null`을 반환하도록 처리했습니다.
- **인프라: Swagger(OpenAPI) 전역 설정 추가**
  - `OpenApiConfig`에 `SpringDocUtils`를 활용하여 `@LoginUser`, `@LoginAdmin` 파라미터가 Swagger 문서에 노출되지 않도록 전역 무시(Ignore) 설정을 추가했습니다.
- **리팩토링: 전 도메인 Controller & Api 인터페이스 디커플링**
  - User, Card, Deck, ActiveLog, Admin 등 모든 도메인의 27개 컨트롤러/Api 인터페이스를 전면 수정했습니다.
  - 낡은 `@AuthenticationPrincipal` 및 `UserDetails` 객체 의존성을 완전히 제거하고 커스텀 어노테이션으로 교체했습니다.

### 스크린샷 (선택)

![1](https://github.com/user-attachments/assets/ea725325-bfdd-45f4-af89-61ae9a19eecc)
<img width="512" height="144" alt="2" src="https://github.com/user-attachments/assets/04a5dc1c-066d-440e-88e0-8ca4f9c21bbf" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

- **Spring Security 의존성 제거:** Controller 및 Api 인터페이스 계층에서 `org.springframework.security.*` 패키지 import가 완벽하게 사라졌는지 확인해 주세요!
- **비로그인 분기 처리:** 인증이 필수가 아닌 API(예: `CardQueryApi.getCards`)에서 기존 로직이 깨지지 않고 `userId == null` 분기를 통해 정상적으로 동작하는지 흐름을 살펴봐 주세요.
- **Swagger UI 더블 체크:** 로컬 환경에서 Swagger 구동 시, 파라미터 목록에 불필요한 `userId`나 `adminId`가 노출되지 않고 깔끔하게 렌더링되는지 확인 부탁드립니다. 

[DK-440]: https://potenup-final.atlassian.net/browse/DK-440?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ