### PR TITLE
[CHORE] 개발 환경 logging Loki host 환경 변수 사용

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -83,9 +83,10 @@
     </appender>
 
     <springProfile name="dev">
+        <springProperty scope="context" name="DEV_LOKI_HOST" source="loki.host"/>
         <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
             <http>
-                <url>http://localhost:3100/loki/api/v1/push</url>
+                <url>${DEV_LOKI_HOST}/loki/api/v1/push</url>
             </http>
             <format>
                 <label>


### PR DESCRIPTION
## #️⃣연관된 이슈

[DK-443](https://potenup-final.atlassian.net/browse/DK-443)

## 📝작업 내용

logging 설정 파일에서 dev 프로필의 loki를 localhost로 잡고 있었습니다. 개발 환경 설정에 맞춰 환경 변수로 주입할 수 있게 변경했습니다.



[DK-443]: https://potenup-final.atlassian.net/browse/DK-443?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ