### PR TITLE
[CHORE] 사용자 테이블 이메일 UK 제거

### DIFF
--- a/src/main/resources/db/migration/V4__drop_legacy_users_email_uk.sql
+++ b/src/main/resources/db/migration/V4__drop_legacy_users_email_uk.sql
@@ -1,0 +1,3 @@
+-- 환경별 이름 불일치로 제거되지 않은 email 단독 UK 제거
+ALTER TABLE users DROP CONSTRAINT IF EXISTS uc_users_email;
+ALTER TABLE users DROP CONSTRAINT IF EXISTS uk6dotkott2kjsp8vw4d0m25fb7;


### PR DESCRIPTION
## #️⃣연관된 이슈

[DK-441](https://potenup-final.atlassian.net/browse/DK-441)

## 📝작업 내용
develop 환경에서 uk 제약 조건 확인해보니 `uc_users_email`로 잡혀있고, prod 환경에서는 `uk6dotkott2kjsp8vw4d0m25fb7`으로 잡혀있어 제거합니다.

[DK-441]: https://potenup-final.atlassian.net/browse/DK-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ