### PR TITLE
[CHORE] Flyway CI 작업

### DIFF
--- a/.github/workflows/dev-cd.yml
+++ b/.github/workflows/dev-cd.yml
@@ -50,7 +50,14 @@ jobs:
           chmod +x gradlew
           ./gradlew clean build -x test
 
-      - name: 5. Docker Compose로 Dev 서버 재실행
+      - name: 5. Flyway 마이그레이션 실행
+        run: |
+          ./gradlew flywayMigrate \
+            -Dflyway.url=jdbc:postgresql://${{ secrets.DEV_DB_HOST }}:${{ secrets.DEV_DB_PORT }}/dekk \
+            -Dflyway.user=${{ secrets.DEV_FLYWAY_USERNAME }} \
+            -Dflyway.password=${{ secrets.DEV_FLYWAY_PASSWORD }}
+
+      - name: 6. Docker Compose로 Dev 서버 재실행
         run: |
           docker compose -f docker-compose-dev.yml down
           docker compose -f docker-compose-dev.yml build --no-cache

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,16 @@
+buildscript {
+    dependencies {
+        classpath 'org.flywaydb:flyway-database-postgresql:11.7.2'
+        classpath 'org.postgresql:postgresql:42.7.10'
+    }
+}
+
 plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.11'
     id 'io.spring.dependency-management' version '1.1.7'
     id "com.diffplug.spotless" version "8.3.0"
+    id 'org.flywaydb.flyway' version '11.7.2'
 }
 
 group = 'com.dekk'
@@ -26,6 +34,14 @@ configurations {
         extendsFrom annotationProcessor
     }
 }
+
+ext['flyway.version'] = '11.7.2'
+
+flyway {
+    baselineOnMigrate = true
+    locations = ['filesystem:src/main/resources/db/migration']
+}
+
 
 spotless {
     java {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,9 +20,7 @@ spring:
         enabled: false
 
   flyway:
-    enabled: true
-    locations: classpath:db/migration
-    baseline-on-migrate: true
+    enabled: false
 
   jpa:
     hibernate:


### PR DESCRIPTION
## #️⃣연관된 이슈

[DK-445](https://potenup-final.atlassian.net/browse/DK-445)

## 📝작업 내용
> 일단 dev에서 사용해본 후 prod 환경에 적용 시켜보는 것이 좋을 거 같아 dev에만 우선 적용합니다.

Flyway를 Gradle 플러그인으로 분리하여 CI 단독 실행 가능하도록 구성하였습니다.

- Flyway Gradle 플러그인 추가 (CI에서 flywayMigrate 태스크로 실행)
- buildscript classpath에 flyway-database-postgresql, postgresql 추가
- flyway 설정 블록 추가 (baselineOnMigrate, filesystem locations)

[DK-445]: https://potenup-final.atlassian.net/browse/DK-445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ