### PR TITLE
[REFACTOR] 크롤링 카드 생성시 필수 값을 옵션 값으로 변경

### DIFF
--- a/src/main/java/com/dekk/app/card/domain/model/Card.java
+++ b/src/main/java/com/dekk/app/card/domain/model/Card.java
@@ -47,7 +47,7 @@ public class Card extends BaseTimeEntity {
     @Column(name = "tags")
     private String tags;
 
-    @Column(name = "origin_id", nullable = false, updatable = false)
+    @Column(name = "origin_id", updatable = false)
     private String originId;
 
     @Enumerated(EnumType.STRING)
@@ -55,7 +55,6 @@ public class Card extends BaseTimeEntity {
     private CardStatus status;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private Platform platform;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/dekk/app/card/domain/model/Product.java
+++ b/src/main/java/com/dekk/app/card/domain/model/Product.java
@@ -29,7 +29,7 @@ public class Product extends BaseTimeEntity {
 
     private Integer price;
 
-    @Column(name = "origin_id", nullable = false)
+    @Column(name = "origin_id")
     private String originId;
 
     private String option;


### PR DESCRIPTION
## #️⃣연관된 이슈
[지라 티켓 번호](https://potenup-final.atlassian.net/browse/DK-453)
#197 flyway migragion 쿼리

## 📝작업 내용
- 크롤링 카드 생성시 플랫폼에서 제공하는 origin_id, platform 과 같은 데이터를 필수 값으로 설정했지만, 사용자에 의해 카드를 생성하는 경우 해당 값이 없습니다. cards. origin_id, cards. platform, products. origin_id에서 nullable 제약 조건을 제거했습니다.