### PR TITLE
[HOTFIX] 인증/인가 보안 엣지 케이스 및 401 무한루프 해결(#DK-444)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,7 +49,7 @@ docs
 .env
 
 # Spring Boot 민감한 설정 파일
-src/main/resources/application-dev.yml
+src/main/resources/application-local.yml
 
 # yml 파일 이름에 secret이나 prod가 들어간다면 패턴으로 모두 무시
 *secret*.yml

--- a/src/main/java/com/dekk/app/auth/presentation/controller/AuthApi.java
+++ b/src/main/java/com/dekk/app/auth/presentation/controller/AuthApi.java
@@ -25,7 +25,7 @@ public interface AuthApi {
                         description = "토큰 갱신 성공 (SA20001)"),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "401",
-                        description = "유효하지 않거나 만료된 리프레시 토큰 (EA40101)")
+                        description = "유효하지 않은 리프레시 토큰입니다 (EA40105)")
             })
     @ApiErrorExceptions({AuthErrorCode.class})
     ResponseEntity<ApiResponse<Void>> refreshToken(

--- a/src/main/java/com/dekk/app/auth/presentation/controller/AuthApi.java
+++ b/src/main/java/com/dekk/app/auth/presentation/controller/AuthApi.java
@@ -25,7 +25,7 @@ public interface AuthApi {
                         description = "토큰 갱신 성공 (SA20001)"),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "401",
-                        description = "유효하지 않은 리프레시 토큰입니다 (EA40105)")
+                        description = "토큰 없음/형식 오류(EA40101), 만료(EA40102), 유효하지 않음(EA40105)")
             })
     @ApiErrorExceptions({AuthErrorCode.class})
     ResponseEntity<ApiResponse<Void>> refreshToken(

--- a/src/main/java/com/dekk/app/auth/presentation/controller/AuthApi.java
+++ b/src/main/java/com/dekk/app/auth/presentation/controller/AuthApi.java
@@ -1,6 +1,9 @@
 package com.dekk.app.auth.presentation.controller;
 
+import com.dekk.app.auth.domain.exception.AuthErrorCode;
 import com.dekk.global.response.ApiResponse;
+import com.dekk.global.security.annotation.LoginUser;
+import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -9,29 +12,33 @@ import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.CookieValue;
 
-@Tag(name = "인증 API", description = "토큰 재발급 및 로그아웃 API (HttpOnly 쿠키 기반)")
+@Tag(name = "인증/토큰 API", description = "쿠키 기반 JWT 토큰 갱신 및 로그아웃 API (HttpOnly 쿠키를 제어합니다.)")
 public interface AuthApi {
 
-    @Operation(summary = "토큰 재발급", description = "쿠키에 담긴 리프레시 토큰을 검증하여 새로운 액세스/리프레시 토큰 쿠키를 발급합니다.")
+    @Operation(
+            summary = "Access Token 갱신 (리프레시)",
+            description = "브라우저에 저장된 HttpOnly Refresh Token 쿠키를 이용해 Access Token 쿠키를 재발급 받습니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "200",
-                        description = "성공 (SA20001)"),
+                        description = "토큰 갱신 성공 (SA20001)"),
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "401",
-                        description = "유효하지 않은 토큰(EA40101)")
+                        description = "유효하지 않거나 만료된 리프레시 토큰 (EA40101)")
             })
+    @ApiErrorExceptions({AuthErrorCode.class})
     ResponseEntity<ApiResponse<Void>> refreshToken(
-            @Parameter(hidden = true) @CookieValue(value = "refresh_token") String refreshToken,
-            @Parameter(hidden = true) HttpServletResponse response);
+            @Parameter(hidden = true) @CookieValue(value = "refresh_token", required = false) String refreshToken,
+            HttpServletResponse response);
 
-    @Operation(summary = "로그아웃", description = "발급된 인증 쿠키를 모두 삭제(만료) 처리합니다.")
+    @Operation(summary = "로그아웃", description = "서버의 Refresh Token을 삭제 처리하고, 프론트 브라우저의 JWT 쿠키를 만료시킵니다.")
     @ApiResponses(
             value = {
                 @io.swagger.v3.oas.annotations.responses.ApiResponse(
                         responseCode = "200",
                         description = "로그아웃 성공 (SA20002)")
             })
-    ResponseEntity<ApiResponse<Void>> logout(@Parameter(hidden = true) HttpServletResponse response);
+    @ApiErrorExceptions({AuthErrorCode.class})
+    ResponseEntity<ApiResponse<Void>> logout(@LoginUser Long userId, HttpServletResponse response);
 }

--- a/src/main/java/com/dekk/app/auth/presentation/controller/AuthController.java
+++ b/src/main/java/com/dekk/app/auth/presentation/controller/AuthController.java
@@ -5,6 +5,7 @@ import com.dekk.app.auth.application.command.TokenRefreshCommand;
 import com.dekk.app.auth.application.dto.result.TokenRefreshResult;
 import com.dekk.app.auth.presentation.response.AuthResultCode;
 import com.dekk.global.response.ApiResponse;
+import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.security.util.CookieUtil;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Value;
@@ -39,6 +40,7 @@ public class AuthController implements AuthApi {
     public ResponseEntity<ApiResponse<Void>> refreshToken(
             @CookieValue(value = CookieUtil.REFRESH_TOKEN_NAME, required = false) String refreshToken,
             HttpServletResponse response) {
+
         TokenRefreshResult result = authCommandService.refreshToken(new TokenRefreshCommand(refreshToken));
 
         cookieUtil.addCookie(response, CookieUtil.ACCESS_TOKEN_NAME, result.accessToken(), accessTokenMaxAge);
@@ -49,7 +51,11 @@ public class AuthController implements AuthApi {
 
     @Override
     @PostMapping("/logout")
-    public ResponseEntity<ApiResponse<Void>> logout(HttpServletResponse response) {
+    public ResponseEntity<ApiResponse<Void>> logout(@LoginUser Long userId, HttpServletResponse response) {
+
+        if (userId != null) {
+            authCommandService.logout(userId);
+        }
 
         cookieUtil.deleteCookie(response, CookieUtil.ACCESS_TOKEN_NAME);
         cookieUtil.deleteCookie(response, CookieUtil.REFRESH_TOKEN_NAME);

--- a/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -39,9 +39,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         "/actuator/**"
     };
 
+    private static final AntPathMatcher PATH_MATCHER = new AntPathMatcher();
+
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
-    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper) {
         this.jwtTokenProvider = jwtTokenProvider;
@@ -51,7 +52,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
-        return Arrays.stream(EXCLUDE_PATHS).anyMatch(pattern -> pathMatcher.match(pattern, path));
+        for (String pattern : EXCLUDE_PATHS) {
+            if (PATH_MATCHER.match(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -17,6 +17,7 @@ import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -25,12 +26,32 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String ADMIN_TOKEN_COOKIE_NAME = "admin_access_token";
 
+    private static final String[] EXCLUDE_PATHS = {
+        "/w/v1/auth/refresh",
+        "/adm/v1/auth/login",
+        "/oauth2/authorization/**",
+        "/login/oauth2/code/**",
+        "/i/v1/**",
+        "/swagger-ui/**",
+        "/swagger-ui.html",
+        "/v3/api-docs/**",
+        "/v3/api-docs",
+        "/actuator/**"
+    };
+
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.objectMapper = objectMapper;
+    }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return Arrays.stream(EXCLUDE_PATHS).anyMatch(pattern -> pathMatcher.match(pattern, path));
     }
 
     @Override
@@ -63,6 +84,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             handleAuthenticationException(response, e);
             return;
         }
+
         filterChain.doFilter(request, response);
     }
 

--- a/src/main/java/com/dekk/global/swagger/ApiErrorExceptionsCustomizer.java
+++ b/src/main/java/com/dekk/global/swagger/ApiErrorExceptionsCustomizer.java
@@ -39,11 +39,19 @@ public class ApiErrorExceptionsCustomizer implements OperationCustomizer {
                     ApiResponse response =
                             responses.computeIfAbsent(statusCode, k -> new ApiResponse().description("에러 응답"));
 
-                    if (response.getContent() == null) {
-                        response.setContent(new Content().addMediaType("application/json", new MediaType()));
+                    Content content = response.getContent();
+                    if (content == null) {
+                        content = new Content();
+                        response.setContent(content);
                     }
 
-                    response.getContent().get("application/json").addExamples(errorCode.name(), example);
+                    MediaType mediaType = content.get("application/json");
+                    if (mediaType == null) {
+                        mediaType = new MediaType();
+                        content.addMediaType("application/json", mediaType);
+                    }
+
+                    mediaType.addExamples(errorCode.name(), example);
                 }
             }
         }

--- a/src/main/java/com/dekk/global/swagger/ApiErrorExceptionsCustomizer.java
+++ b/src/main/java/com/dekk/global/swagger/ApiErrorExceptionsCustomizer.java
@@ -45,10 +45,11 @@ public class ApiErrorExceptionsCustomizer implements OperationCustomizer {
                         response.setContent(content);
                     }
 
-                    MediaType mediaType = content.get("application/json");
+                    String jsonMediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+                    MediaType mediaType = content.get(jsonMediaType);
                     if (mediaType == null) {
                         mediaType = new MediaType();
-                        content.addMediaType("application/json", mediaType);
+                        content.addMediaType(jsonMediaType, mediaType);
                     }
 
                     mediaType.addExamples(errorCode.name(), example);

--- a/src/main/java/com/dekk/global/swagger/ApiErrorExceptionsCustomizer.java
+++ b/src/main/java/com/dekk/global/swagger/ApiErrorExceptionsCustomizer.java
@@ -1,5 +1,7 @@
 package com.dekk.global.swagger;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
 import com.dekk.global.error.ErrorCode;
 import com.dekk.global.error.ErrorResponse;
 import io.swagger.v3.oas.models.Operation;
@@ -45,7 +47,7 @@ public class ApiErrorExceptionsCustomizer implements OperationCustomizer {
                         response.setContent(content);
                     }
 
-                    String jsonMediaType = org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+                    String jsonMediaType = APPLICATION_JSON_VALUE;
                     MediaType mediaType = content.get(jsonMediaType);
                     if (mediaType == null) {
                         mediaType = new MediaType();


### PR DESCRIPTION
## #️⃣연관된 이슈

> # [DK-444](https://potenup-final.atlassian.net/browse/DK-444)

## 📝작업 내용

> 이번 PR은 운영 환경에서 발생할 수 있는 **인증/인가 아키텍처의 치명적 엣지 케이스(401 무한루프)와 보안 취약점(토큰 탈취)을 해결한 수정 작업**입니다.

**1. [버그 수정] 토큰 갱신 시 발생하는 401 무한루프 차단**
* `JwtAuthenticationFilter`의 `EXCLUDE_PATHS`에 `/w/v1/auth/refresh` 경로를 추가하여 토큰 검증 우회(Bypass) 적용.
* **(수정 배경):** 토큰 수명과 쿠키 수명이 동일하게 설정되어 있어도, 네트워크 지연(Latency)에 따른 시차(Clock Skew)와 프론트엔드 인터셉터의 재시도 로직이 맞물려 **브라우저 쿠키는 살아있으나, 내부 JWT는 만료된 상태**로 API 요청이 들어오는 찰나의 엣지 케이스가 존재했습니다. 이 경우 필터가 401을 뱉어 프론트엔드가 무한루프에 빠지는 현상을 막기 위해, `/refresh` 요청만큼은 문지기(필터)를 무사통과하도록 조치했습니다.

**2. [보안 패치] 로그아웃 시 서버 측 Refresh Token 완벽 소각**
* `AuthController.logout` API에 `@LoginUser` 식별자를 추가하여 `AuthCommandService`와 연동.
* 기존에는 브라우저의 쿠키(`Max-Age=0`)만 삭제되었으나, 이제 로그아웃 즉시 서버(Redis)의 `RT:{userId}` 키를 완벽하게 삭제(`deleteByUserId`)합니다. 이를 통해 탈취된 Refresh Token의 생명 연장을 원천 차단하고 RTR(Refresh Token Rotation) 보안을 강화했습니다.

**3. [기타 수정 사항]**
* `ApiErrorExceptionsCustomizer`: Swagger UI가 API 명세서를 렌더링할 때 간헐적으로 발생하던 `NullPointerException` 방어 코드(`Content`, `MediaType` null 체크)를 추가하여 500 에러를 해결했습니다.
* `AuthApi`: SpringDoc이 기본적으로 무시하는 `HttpServletResponse` 객체에 불필요하게 붙어있던 `@Parameter(hidden = true)`를 제거했습니다. (`@CookieValue`의 hidden 처리는 명세서 입력창 방지를 위해 유지)
* `.gitignore`: 로컬 환경 테스트 전용 설정 파일(`application-local.yml`)이 깃에 꼬이는 것을 방지하기 위해 예외 처리했습니다.

### 스크린샷 (선택)

> **[Hotfix 1] 401 무한루프 해결 검증**


**[AS-IS]**
<img width="1512" height="982" alt="401에러" src="https://github.com/user-attachments/assets/c721bdd7-1a1d-4be0-8840-b8a190ba72ac" />
 만료된 토큰으로 인해 필터에서 `401 Unauthorized` 차단됨

**[TO-BE]**
<img width="1512" height="982" alt="리팩토링후 성공" src="https://github.com/user-attachments/assets/a57bef6f-fdb0-44f0-9dfa-1506a578f948" />
 필터 우회(Bypass) 후 `200 OK` 및 새 토큰 정상 발급됨

<br>

> **[Hotfix 2] 로그아웃 시 Redis 소각 검증**

**[AS-IS]**
<img width="748" height="944" alt="로그아웃전" src="https://github.com/user-attachments/assets/3b1d28ba-8424-472d-8346-99fa1d111a16" />
 로그인 상태일 때 Redis에 토큰이 보관된 상태

**[TO-BE]**
<img width="748" height="944" alt="로그아웃후" src="https://github.com/user-attachments/assets/54b86c1e-d0c4-4e16-8bcf-797a3bde7fdf" />

 로그아웃 API 호출 직후, Redis 장부에서 `(nil)`로 완벽히 소각(Burn)됨

## 💬리뷰 요구사항(선택)

> * `JwtAuthenticationFilter`에서 `/refresh` API를 우회하더라도, 이후 `AuthCommandService`에서 서명 검증, 만료일 검사, 타입 검사, Redis 장부 1:1 대조 등 5중 검증을 거치므로 보안상 안전합니다. 팀원분들은 이 점 참고하여 리뷰 부탁드립니다!
> * 로컬 테스트가 필요하신 분들은 `application-local.yml` 파일을 개별적으로 생성해서 사용해 주시면 됩니다.

[DK-444]: https://potenup-final.atlassian.net/browse/DK-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ