### PR TITLE
[FEAT] Resource 도메인 생성

### DIFF
--- a/src/main/java/com/dekk/app/resource/domain/exception/ResourceBusinessException.java
+++ b/src/main/java/com/dekk/app/resource/domain/exception/ResourceBusinessException.java
@@ -1,0 +1,10 @@
+package com.dekk.app.resource.domain.exception;
+
+import com.dekk.global.error.BusinessException;
+import com.dekk.global.error.ErrorCode;
+
+public class ResourceBusinessException extends BusinessException {
+    public ResourceBusinessException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/dekk/app/resource/domain/exception/ResourceErrorCode.java
+++ b/src/main/java/com/dekk/app/resource/domain/exception/ResourceErrorCode.java
@@ -1,0 +1,37 @@
+package com.dekk.app.resource.domain.exception;
+
+import com.dekk.global.error.ErrorCode;
+import org.springframework.http.HttpStatus;
+
+public enum ResourceErrorCode implements ErrorCode {
+    RESOURCE_TYPE_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40001", "리소스 타입은 필수값입니다."),
+    ORIGINAL_KEY_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40002", "원본 파일 키는 필수값입니다."),
+    ORIGINAL_FILE_NAME_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40003", "원본 파일명은 필수값입니다."),
+    EXPIRES_AT_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40004", "만료 시간은 필수값입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    ResourceErrorCode(HttpStatus httpStatus, String code, String message) {
+        this.httpStatus = httpStatus;
+        this.code = code;
+        this.message = message;
+    }
+
+    @Override
+    public HttpStatus status() {
+        return httpStatus;
+    }
+
+    @Override
+    public String code() {
+        return code;
+    }
+
+    @Override
+    public String message() {
+        return message;
+    }
+}

--- a/src/main/java/com/dekk/app/resource/domain/exception/ResourceErrorCode.java
+++ b/src/main/java/com/dekk/app/resource/domain/exception/ResourceErrorCode.java
@@ -8,8 +8,13 @@ public enum ResourceErrorCode implements ErrorCode {
     ORIGINAL_KEY_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40002", "원본 파일 키는 필수값입니다."),
     ORIGINAL_FILE_NAME_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40003", "원본 파일명은 필수값입니다."),
     EXPIRES_AT_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40004", "만료 시간은 필수값입니다."),
-    ORIGINAL_FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "ER40005", "원본 파일명은 255자를 초과할 수 없습니다.")
-    ;
+    ORIGINAL_FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "ER40005", "원본 파일명은 255자를 초과할 수 없습니다."),
+    PROCESSED_KEY_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40006", "처리된 파일 키는 필수값입니다."),
+    IMAGE_URL_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40007", "이미지 URL은 필수값입니다."),
+    FILE_SIZE_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40008", "파일 크기는 필수값입니다."),
+    CONTENT_TYPE_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40009", "컨텐츠 타입은 필수값입니다."),
+
+    INVALID_STATUS_CHANGE(HttpStatus.CONFLICT, "ER40901", "현재 상태에서는 상태 변경이 불가능합니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/dekk/app/resource/domain/exception/ResourceErrorCode.java
+++ b/src/main/java/com/dekk/app/resource/domain/exception/ResourceErrorCode.java
@@ -8,6 +8,7 @@ public enum ResourceErrorCode implements ErrorCode {
     ORIGINAL_KEY_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40002", "원본 파일 키는 필수값입니다."),
     ORIGINAL_FILE_NAME_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40003", "원본 파일명은 필수값입니다."),
     EXPIRES_AT_IS_REQUIRED(HttpStatus.BAD_REQUEST, "ER40004", "만료 시간은 필수값입니다."),
+    ORIGINAL_FILE_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "ER40005", "원본 파일명은 255자를 초과할 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dekk/app/resource/domain/model/Resource.java
+++ b/src/main/java/com/dekk/app/resource/domain/model/Resource.java
@@ -45,7 +45,7 @@ public class Resource extends BaseTimeEntity {
     @Column(name = "original_key", length = 500)
     private String originalKey;
 
-    @Column(name = "original_file_name", length = 255)
+    @Column(name = "original_file_name")
     private String originalFileName;
 
     @Column(name = "processed_key", length = 500)
@@ -80,12 +80,19 @@ public class Resource extends BaseTimeEntity {
         if (resourceType == null) {
             throw new ResourceBusinessException(ResourceErrorCode.RESOURCE_TYPE_IS_REQUIRED);
         }
+
         if (originalKey == null || originalKey.isBlank()) {
             throw new ResourceBusinessException(ResourceErrorCode.ORIGINAL_KEY_IS_REQUIRED);
         }
+
         if (originalFileName == null || originalFileName.isBlank()) {
             throw new ResourceBusinessException(ResourceErrorCode.ORIGINAL_FILE_NAME_IS_REQUIRED);
         }
+
+        if (originalFileName.length() > 255) {
+            throw new ResourceBusinessException(ResourceErrorCode.ORIGINAL_FILE_NAME_TOO_LONG);
+        }
+
         if (expiresAt == null) {
             throw new ResourceBusinessException(ResourceErrorCode.EXPIRES_AT_IS_REQUIRED);
         }

--- a/src/main/java/com/dekk/app/resource/domain/model/Resource.java
+++ b/src/main/java/com/dekk/app/resource/domain/model/Resource.java
@@ -60,8 +60,7 @@ public class Resource extends BaseTimeEntity {
     @Column(name = "expires_at")
     private LocalDateTime expiresAt;
 
-    private Resource(
-            ResourceType resourceType, String originalKey, String originalFileName, LocalDateTime expiresAt) {
+    private Resource(ResourceType resourceType, String originalKey, String originalFileName, LocalDateTime expiresAt) {
         this.publicId = UUID.randomUUID();
         this.resourceType = resourceType;
         this.status = ResourceStatus.PENDING;

--- a/src/main/java/com/dekk/app/resource/domain/model/Resource.java
+++ b/src/main/java/com/dekk/app/resource/domain/model/Resource.java
@@ -1,0 +1,126 @@
+package com.dekk.app.resource.domain.model;
+
+import com.dekk.app.resource.domain.exception.ResourceBusinessException;
+import com.dekk.app.resource.domain.exception.ResourceErrorCode;
+import com.dekk.app.resource.domain.model.enums.ResourceStatus;
+import com.dekk.app.resource.domain.model.enums.ResourceType;
+import com.dekk.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Table(name = "resources")
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Resource extends BaseTimeEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "public_id", nullable = false, unique = true, updatable = false)
+    private UUID publicId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "resource_type", nullable = false, length = 20)
+    private ResourceType resourceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 20)
+    private ResourceStatus status;
+
+    @Column(name = "image_url", length = 500)
+    private String imageUrl;
+
+    @Column(name = "original_key", length = 500)
+    private String originalKey;
+
+    @Column(name = "original_file_name", length = 255)
+    private String originalFileName;
+
+    @Column(name = "processed_key", length = 500)
+    private String processedKey;
+
+    @Column(name = "content_type", length = 100)
+    private String contentType;
+
+    @Column(name = "file_size")
+    private Long fileSize;
+
+    @Column(name = "expires_at")
+    private LocalDateTime expiresAt;
+
+    private Resource(
+            ResourceType resourceType, String originalKey, String originalFileName, LocalDateTime expiresAt) {
+        this.publicId = UUID.randomUUID();
+        this.resourceType = resourceType;
+        this.status = ResourceStatus.PENDING;
+        this.originalKey = originalKey;
+        this.originalFileName = originalFileName;
+        this.expiresAt = expiresAt;
+    }
+
+    public static Resource createPending(
+            ResourceType resourceType, String originalKey, String originalFileName, LocalDateTime expiresAt) {
+        validateCreatePendingParameters(resourceType, originalKey, originalFileName, expiresAt);
+        return new Resource(resourceType, originalKey, originalFileName, expiresAt);
+    }
+
+    private static void validateCreatePendingParameters(
+            ResourceType resourceType, String originalKey, String originalFileName, LocalDateTime expiresAt) {
+        if (resourceType == null) {
+            throw new ResourceBusinessException(ResourceErrorCode.RESOURCE_TYPE_IS_REQUIRED);
+        }
+        if (originalKey == null || originalKey.isBlank()) {
+            throw new ResourceBusinessException(ResourceErrorCode.ORIGINAL_KEY_IS_REQUIRED);
+        }
+        if (originalFileName == null || originalFileName.isBlank()) {
+            throw new ResourceBusinessException(ResourceErrorCode.ORIGINAL_FILE_NAME_IS_REQUIRED);
+        }
+        if (expiresAt == null) {
+            throw new ResourceBusinessException(ResourceErrorCode.EXPIRES_AT_IS_REQUIRED);
+        }
+    }
+
+    public void markAsProcessed(String processedKey, String imageUrl, Long fileSize, String contentType) {
+        this.status = ResourceStatus.PROCESSED;
+        this.processedKey = processedKey;
+        this.imageUrl = imageUrl;
+        this.fileSize = fileSize;
+        this.contentType = contentType;
+    }
+
+    public void markAsFailed() {
+        this.status = ResourceStatus.FAILED;
+    }
+
+    public void markAsExpired() {
+        this.status = ResourceStatus.EXPIRED;
+    }
+
+    public boolean isProcessed() {
+        return this.status.isProcessed();
+    }
+
+    public boolean canBeUsed() {
+        return this.status.canBeUsed();
+    }
+
+    public boolean isCardImage() {
+        return this.resourceType == ResourceType.CARD_IMAGE;
+    }
+
+    public boolean isProductImage() {
+        return this.resourceType == ResourceType.PRODUCT_IMAGE;
+    }
+}

--- a/src/main/java/com/dekk/app/resource/domain/model/Resource.java
+++ b/src/main/java/com/dekk/app/resource/domain/model/Resource.java
@@ -99,6 +99,9 @@ public class Resource extends BaseTimeEntity {
     }
 
     public void markAsProcessed(String processedKey, String imageUrl, Long fileSize, String contentType) {
+        validateStatusChange(ResourceStatus.PROCESSED);
+        validateMarkAsProcessedParameters(processedKey, imageUrl, fileSize, contentType);
+
         this.status = ResourceStatus.PROCESSED;
         this.processedKey = processedKey;
         this.imageUrl = imageUrl;
@@ -106,12 +109,41 @@ public class Resource extends BaseTimeEntity {
         this.contentType = contentType;
     }
 
+    private static void validateMarkAsProcessedParameters(
+            String processedKey, String imageUrl, Long fileSize, String contentType) {
+        if (processedKey == null || processedKey.isBlank()) {
+            throw new ResourceBusinessException(ResourceErrorCode.PROCESSED_KEY_IS_REQUIRED);
+        }
+
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new ResourceBusinessException(ResourceErrorCode.IMAGE_URL_IS_REQUIRED);
+        }
+
+        if (fileSize == null) {
+            throw new ResourceBusinessException(ResourceErrorCode.FILE_SIZE_IS_REQUIRED);
+        }
+
+        if (contentType == null || contentType.isBlank()) {
+            throw new ResourceBusinessException(ResourceErrorCode.CONTENT_TYPE_IS_REQUIRED);
+        }
+    }
+
     public void markAsFailed() {
+        validateStatusChange(ResourceStatus.FAILED);
+
         this.status = ResourceStatus.FAILED;
     }
 
     public void markAsExpired() {
+        validateStatusChange(ResourceStatus.EXPIRED);
+
         this.status = ResourceStatus.EXPIRED;
+    }
+
+    private void validateStatusChange(ResourceStatus targetStatus) {
+        if (!this.status.canChangeTo(targetStatus)) {
+            throw new ResourceBusinessException(ResourceErrorCode.INVALID_STATUS_CHANGE);
+        }
     }
 
     public boolean isProcessed() {

--- a/src/main/java/com/dekk/app/resource/domain/model/enums/ResourceStatus.java
+++ b/src/main/java/com/dekk/app/resource/domain/model/enums/ResourceStatus.java
@@ -1,0 +1,23 @@
+package com.dekk.app.resource.domain.model.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResourceStatus {
+    PENDING("업로드 대기 중"),
+    PROCESSED("처리 완료"),
+    FAILED("처리 실패"),
+    EXPIRED("만료됨");
+
+    private final String description;
+
+    public boolean isProcessed() {
+        return this == PROCESSED;
+    }
+
+    public boolean canBeUsed() {
+        return this == PROCESSED;
+    }
+}

--- a/src/main/java/com/dekk/app/resource/domain/model/enums/ResourceStatus.java
+++ b/src/main/java/com/dekk/app/resource/domain/model/enums/ResourceStatus.java
@@ -20,4 +20,12 @@ public enum ResourceStatus {
     public boolean canBeUsed() {
         return this == PROCESSED;
     }
+
+    public boolean canChangeTo(ResourceStatus targetStatus) {
+        if (this == PENDING) {
+            return targetStatus == PROCESSED || targetStatus == FAILED || targetStatus == EXPIRED;
+        }
+
+        return false;
+    }
 }

--- a/src/main/java/com/dekk/app/resource/domain/model/enums/ResourceType.java
+++ b/src/main/java/com/dekk/app/resource/domain/model/enums/ResourceType.java
@@ -1,0 +1,24 @@
+package com.dekk.app.resource.domain.model.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ResourceType {
+    CARD_IMAGE("카드 이미지"),
+    PRODUCT_IMAGE("상품 이미지");
+
+    private final String description;
+
+    public String getKeyPrefix() {
+        return switch (this) {
+            case CARD_IMAGE -> "card-images";
+            case PRODUCT_IMAGE -> "product-images";
+        };
+    }
+
+    public String getOriginalKeyPrefix() {
+        return "original/" + getKeyPrefix();
+    }
+}

--- a/src/test/java/com/dekk/app/resource/domain/model/ResourceTest.java
+++ b/src/test/java/com/dekk/app/resource/domain/model/ResourceTest.java
@@ -1,0 +1,329 @@
+package com.dekk.app.resource.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.dekk.app.resource.domain.exception.ResourceBusinessException;
+import com.dekk.app.resource.domain.exception.ResourceErrorCode;
+import com.dekk.app.resource.domain.model.enums.ResourceStatus;
+import com.dekk.app.resource.domain.model.enums.ResourceType;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("Resource 도메인 테스트")
+class ResourceTest {
+
+    @Nested
+    class CreatePendingTest {
+
+        @Test
+        @DisplayName("정상적인 파라미터로 PENDING 상태의 CARD_IMAGE Resource를 생성한다")
+        void createPending_CardImage_Success() {
+            // given
+            ResourceType resourceType = ResourceType.CARD_IMAGE;
+            String originalKey = "original/card-images/test.jpg";
+            String originalFileName = "my-photo.jpg";
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(15);
+
+            // when
+            Resource resource = Resource.createPending(resourceType, originalKey, originalFileName, expiresAt);
+
+            // then
+            assertThat(resource).isNotNull();
+            assertThat(resource.getPublicId()).isNotNull();
+            assertThat(resource.getResourceType()).isEqualTo(ResourceType.CARD_IMAGE);
+            assertThat(resource.getStatus()).isEqualTo(ResourceStatus.PENDING);
+            assertThat(resource.getOriginalKey()).isEqualTo(originalKey);
+            assertThat(resource.getOriginalFileName()).isEqualTo(originalFileName);
+            assertThat(resource.getExpiresAt()).isEqualTo(expiresAt);
+            assertThat(resource.getImageUrl()).isNull();
+            assertThat(resource.getProcessedKey()).isNull();
+            assertThat(resource.getContentType()).isNull();
+            assertThat(resource.getFileSize()).isNull();
+        }
+
+        @Test
+        @DisplayName("정상적인 파라미터로 PENDING 상태의 PRODUCT_IMAGE Resource를 생성한다")
+        void createPending_ProductImage_Success() {
+            // given
+            ResourceType resourceType = ResourceType.PRODUCT_IMAGE;
+            String originalKey = "original/product-images/test.jpg";
+            String originalFileName = "product-photo.jpg";
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(15);
+
+            // when
+            Resource resource = Resource.createPending(resourceType, originalKey, originalFileName, expiresAt);
+
+            // then
+            assertThat(resource).isNotNull();
+            assertThat(resource.getResourceType()).isEqualTo(ResourceType.PRODUCT_IMAGE);
+            assertThat(resource.getStatus()).isEqualTo(ResourceStatus.PENDING);
+        }
+
+        @Test
+        @DisplayName("resourceType이 null이면 예외를 발생시킨다")
+        void createPending_ResourceTypeNull_ThrowsException() {
+            // given
+            ResourceType resourceType = null;
+            String originalKey = "original/card-images/test.jpg";
+            String originalFileName = "my-photo.jpg";
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(15);
+
+            // when & then
+            assertThatThrownBy(() -> Resource.createPending(resourceType, originalKey, originalFileName, expiresAt))
+                    .isInstanceOf(ResourceBusinessException.class)
+                    .hasMessageContaining(ResourceErrorCode.RESOURCE_TYPE_IS_REQUIRED.message());
+        }
+
+        @Test
+        @DisplayName("originalKey가 null이면 예외를 발생시킨다")
+        void createPending_OriginalKeyNull_ThrowsException() {
+            // given
+            ResourceType resourceType = ResourceType.CARD_IMAGE;
+            String originalKey = null;
+            String originalFileName = "my-photo.jpg";
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(15);
+
+            // when & then
+            assertThatThrownBy(() -> Resource.createPending(resourceType, originalKey, originalFileName, expiresAt))
+                    .isInstanceOf(ResourceBusinessException.class)
+                    .hasMessageContaining(ResourceErrorCode.ORIGINAL_KEY_IS_REQUIRED.message());
+        }
+
+        @Test
+        @DisplayName("originalKey가 빈 문자열이면 예외를 발생시킨다")
+        void createPending_OriginalKeyBlank_ThrowsException() {
+            // given
+            ResourceType resourceType = ResourceType.CARD_IMAGE;
+            String originalKey = "   ";
+            String originalFileName = "my-photo.jpg";
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(15);
+
+            // when & then
+            assertThatThrownBy(() -> Resource.createPending(resourceType, originalKey, originalFileName, expiresAt))
+                    .isInstanceOf(ResourceBusinessException.class)
+                    .hasMessageContaining(ResourceErrorCode.ORIGINAL_KEY_IS_REQUIRED.message());
+        }
+
+        @Test
+        @DisplayName("originalFileName이 null이면 예외를 발생시킨다")
+        void createPending_OriginalFileNameNull_ThrowsException() {
+            // given
+            ResourceType resourceType = ResourceType.CARD_IMAGE;
+            String originalKey = "original/card-images/test.jpg";
+            String originalFileName = null;
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(15);
+
+            // when & then
+            assertThatThrownBy(() -> Resource.createPending(resourceType, originalKey, originalFileName, expiresAt))
+                    .isInstanceOf(ResourceBusinessException.class)
+                    .hasMessageContaining(ResourceErrorCode.ORIGINAL_FILE_NAME_IS_REQUIRED.message());
+        }
+
+        @Test
+        @DisplayName("originalFileName이 빈 문자열이면 예외를 발생시킨다")
+        void createPending_OriginalFileNameBlank_ThrowsException() {
+            // given
+            ResourceType resourceType = ResourceType.CARD_IMAGE;
+            String originalKey = "original/card-images/test.jpg";
+            String originalFileName = "";
+            LocalDateTime expiresAt = LocalDateTime.now().plusMinutes(15);
+
+            // when & then
+            assertThatThrownBy(() -> Resource.createPending(resourceType, originalKey, originalFileName, expiresAt))
+                    .isInstanceOf(ResourceBusinessException.class)
+                    .hasMessageContaining(ResourceErrorCode.ORIGINAL_FILE_NAME_IS_REQUIRED.message());
+        }
+
+        @Test
+        @DisplayName("expiresAt이 null이면 예외를 발생시킨다")
+        void createPending_ExpiresAtNull_ThrowsException() {
+            // given
+            ResourceType resourceType = ResourceType.CARD_IMAGE;
+            String originalKey = "original/card-images/test.jpg";
+            String originalFileName = "my-photo.jpg";
+            LocalDateTime expiresAt = null;
+
+            // when & then
+            assertThatThrownBy(() -> Resource.createPending(resourceType, originalKey, originalFileName, expiresAt))
+                    .isInstanceOf(ResourceBusinessException.class)
+                    .hasMessageContaining(ResourceErrorCode.EXPIRES_AT_IS_REQUIRED.message());
+        }
+    }
+
+    @Nested
+    class MarkAsProcessedTest {
+
+        @Test
+        @DisplayName("리소스를 PROCESSED 상태로 변경하고 이미지 정보를 저장한다")
+        void markAsProcessed_Success() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.CARD_IMAGE,
+                    "original/card-images/test.jpg",
+                    "my-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+            String processedKey = "card-images/550e8400.webp";
+            String imageUrl = "https://cdn.dekk.com/card-images/550e8400.webp";
+            Long fileSize = 102400L;
+            String contentType = "image/webp";
+
+            // when
+            resource.markAsProcessed(processedKey, imageUrl, fileSize, contentType);
+
+            // then
+            assertThat(resource.getStatus()).isEqualTo(ResourceStatus.PROCESSED);
+            assertThat(resource.getProcessedKey()).isEqualTo(processedKey);
+            assertThat(resource.getImageUrl()).isEqualTo(imageUrl);
+            assertThat(resource.getFileSize()).isEqualTo(fileSize);
+            assertThat(resource.getContentType()).isEqualTo(contentType);
+        }
+    }
+
+    @Nested
+    class MarkAsFailedTest {
+
+        @Test
+        @DisplayName("리소스를 FAILED 상태로 변경한다")
+        void markAsFailed_Success() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.CARD_IMAGE,
+                    "original/card-images/test.jpg",
+                    "my-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+
+            // when
+            resource.markAsFailed();
+
+            // then
+            assertThat(resource.getStatus()).isEqualTo(ResourceStatus.FAILED);
+        }
+    }
+
+    @Nested
+    @DisplayName("markAsExpired 메서드는")
+    class MarkAsExpiredTest {
+
+        @Test
+        @DisplayName("리소스를 EXPIRED 상태로 변경한다")
+        void markAsExpired_Success() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.CARD_IMAGE,
+                    "original/card-images/test.jpg",
+                    "my-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+
+            // when
+            resource.markAsExpired();
+
+            // then
+            assertThat(resource.getStatus()).isEqualTo(ResourceStatus.EXPIRED);
+        }
+    }
+
+    @Nested
+    class IsProcessedTest {
+
+        @Test
+        @DisplayName("PROCESSED 상태일 때 true를 반환한다")
+        void isProcessed_WhenProcessed_ReturnsTrue() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.CARD_IMAGE,
+                    "original/card-images/test.jpg",
+                    "my-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+            resource.markAsProcessed("card-images/test.webp", "https://cdn.dekk.com/test.webp", 100L, "image/webp");
+
+            // when & then
+            assertThat(resource.isProcessed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("PENDING 상태일 때 false를 반환한다")
+        void isProcessed_WhenPending_ReturnsFalse() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.CARD_IMAGE,
+                    "original/card-images/test.jpg",
+                    "my-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+
+            // when & then
+            assertThat(resource.isProcessed()).isFalse();
+        }
+    }
+
+    @Nested
+    class CanBeUsedTest {
+
+        @Test
+        @DisplayName("PROCESSED 상태일 때 true를 반환한다")
+        void canBeUsed_WhenProcessed_ReturnsTrue() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.CARD_IMAGE,
+                    "original/card-images/test.jpg",
+                    "my-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+            resource.markAsProcessed("card-images/test.webp", "https://cdn.dekk.com/test.webp", 100L, "image/webp");
+
+            // when & then
+            assertThat(resource.canBeUsed()).isTrue();
+        }
+
+        @Test
+        @DisplayName("FAILED 상태일 때 false를 반환한다")
+        void canBeUsed_WhenFailed_ReturnsFalse() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.CARD_IMAGE,
+                    "original/card-images/test.jpg",
+                    "my-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+            resource.markAsFailed();
+
+            // when & then
+            assertThat(resource.canBeUsed()).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("타입 확인 메서드는")
+    class TypeCheckTest {
+
+        @Test
+        @DisplayName("CARD_IMAGE 타입일 때 isCardImage()가 true를 반환한다")
+        void isCardImage_WhenCardImage_ReturnsTrue() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.CARD_IMAGE,
+                    "original/card-images/test.jpg",
+                    "my-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+
+            // when & then
+            assertThat(resource.isCardImage()).isTrue();
+            assertThat(resource.isProductImage()).isFalse();
+        }
+
+        @Test
+        @DisplayName("PRODUCT_IMAGE 타입일 때 isProductImage()가 true를 반환한다")
+        void isProductImage_WhenProductImage_ReturnsTrue() {
+            // given
+            Resource resource = Resource.createPending(
+                    ResourceType.PRODUCT_IMAGE,
+                    "original/product-images/test.jpg",
+                    "product-photo.jpg",
+                    LocalDateTime.now().plusMinutes(15));
+
+            // when & then
+            assertThat(resource.isProductImage()).isTrue();
+            assertThat(resource.isCardImage()).isFalse();
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈
- [지라 티켓 번호](https://potenup-final.atlassian.net/browse/DK-454)
- #201 관련 DB 마이그레이션 쿼리
- [의사결정 과정 노션 문서 ](https://www.notion.so/Resource-33c81e1db41d80198b1fe31fc3fea787?source=copy_link)

## 📝작업 내용
### 1. Resource 도메인 작업 목적
 - 클라이언트가 S3에 직접 이미지 업로드 (Presigned URL)
 - Lambda가 WebP 변환 처리
 - 서버는 업로드 상태만 추적 (PENDING → PROCESSED → 카드 생성 가능)
 - 기존 단순히 image url을 저장하는 CardImage, ProductImage와 다른 책임
 - Resource Bounded Context 내에서만 AWS S3같은 외부 연동 로직 작업

 ### 2. 주요 설계 결정: 단일 Resource 테이블
 | 비교 항목 | 분리된 테이블 | 단일 테이블 |
 |---------|------------|----------|
 | 코드 중복 | CardResource, ProductResource 클래스 거의 동일 | Resource 1개만 |
 | 확장성 | 새 타입마다 테이블 추가 | ResourceType enum만 추가 |
 | 쿼리 복잡도 | 테이블별 Repository 필요 | 1개 Repository로 모든 타입 처리 |
 | 유지보수 | 상태 관리 로직 각각 작성 | 1번만 작성 |

### 3. 상태 전이
 ```
 createPending()
     ↓
 [PENDING] ─────────────→ [PROCESSED] ─→ 카드 생성 가능
     ↓                         ↑
     ↓                    markAsProcessed()
     ↓                    (Lambda 콜백)
     ↓
     ├─→ [FAILED] ──────→ 카드 생성 불가
     │   markAsFailed()
     │   (Lambda 처리 실패)
     │
     └─→ [EXPIRED] ─────→ 카드 생성 불가
         markAsExpired()
         (24시간 후 스케줄러)
 ```

### 4. Resource 도메인 메서드 설명
팩토리 메서드
 ```java
 Resource.createPending(ResourceType, originalKey, originalFileName, expiresAt)
 ```
 - **호출 시점**: Presigned URL 발급 시
 - **초기 상태**: PENDING

상태 변경 메서드
 ```java
 resource.markAsProcessed(processedKey, imageUrl, fileSize, contentType)
 ```
 - **호출 시점**: Lambda가 WebP 변환 완료 후 콜백
 - **상태 전이**: PENDING → PROCESSED

 ```java
 resource.markAsFailed()
 ```
 - **호출 시점**: Lambda가 처리 실패 시 콜백
 - **상태 전이**: PENDING → FAILED

 ```java
 resource.markAsExpired()
 ```
 - **호출 시점**: 만료 리소스 정리 스케줄러
 - **상태 전이**: PENDING → EXPIRED

## 👏 리뷰 포인트
- 사용자가 업로드한 원본 리소스의 file name을 저장할 필요가 있을지 고민이 됩니다. 다른 파일 저장 테이블 설계를 봤을 때 UI에 원본 파일명을 보이게 하기 위해 저장하는 것 같은데 저희는 그런 기능이 아직은 없어서 제거해도 될지 고민입니다.