### PR TITLE
[FIX] 스와이프 API를 publicId(UUID) 기반으로 변경

### DIFF
--- a/src/main/java/com/dekk/app/activelog/application/ActiveLogCommandService.java
+++ b/src/main/java/com/dekk/app/activelog/application/ActiveLogCommandService.java
@@ -4,6 +4,7 @@ import com.dekk.app.activelog.application.dto.command.SwipeCommand;
 import com.dekk.app.activelog.domain.model.ActiveLog;
 import com.dekk.app.activelog.domain.model.SwipeType;
 import com.dekk.app.activelog.domain.repository.ActiveLogRepository;
+import com.dekk.app.card.application.CardQueryService;
 import com.dekk.app.deck.application.DeckCardCommandService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,17 +17,20 @@ public class ActiveLogCommandService {
 
     private final ActiveLogRepository activeLogRepository;
     private final DeckCardCommandService deckCardCommandService;
+    private final CardQueryService cardQueryService;
 
     public void saveSwipeAction(SwipeCommand command) {
-        if (activeLogRepository.existsByUserIdAndCardId(command.userId(), command.cardId())) {
+        Long cardId = cardQueryService.getCardIdByPublicId(command.cardPublicId());
+
+        if (activeLogRepository.existsByUserIdAndCardId(command.userId(), cardId)) {
             return;
         }
 
-        ActiveLog activeLog = ActiveLog.create(command.userId(), command.cardId(), command.swipeType());
+        ActiveLog activeLog = ActiveLog.create(command.userId(), cardId, command.swipeType());
         activeLogRepository.save(activeLog);
 
         if (command.swipeType() == SwipeType.LIKE) {
-            deckCardCommandService.saveToDefaultDeck(command.userId(), command.cardId());
+            deckCardCommandService.saveToDefaultDeck(command.userId(), cardId);
         }
     }
 }

--- a/src/main/java/com/dekk/app/activelog/application/dto/command/SwipeCommand.java
+++ b/src/main/java/com/dekk/app/activelog/application/dto/command/SwipeCommand.java
@@ -1,5 +1,6 @@
 package com.dekk.app.activelog.application.dto.command;
 
 import com.dekk.app.activelog.domain.model.SwipeType;
+import java.util.UUID;
 
-public record SwipeCommand(Long userId, Long cardId, SwipeType swipeType) {}
+public record SwipeCommand(Long userId, UUID cardPublicId, SwipeType swipeType) {}

--- a/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogApi.java
+++ b/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogApi.java
@@ -2,6 +2,7 @@ package com.dekk.app.activelog.presentation.controller;
 
 import com.dekk.app.activelog.domain.exception.ActiveLogErrorCode;
 import com.dekk.app.activelog.presentation.request.SwipeRequest;
+import com.dekk.app.card.domain.exception.CardErrorCode;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.annotation.LoginUser;
 import com.dekk.global.swagger.ApiErrorExceptions;
@@ -10,6 +11,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.UUID;
 import org.springframework.http.ResponseEntity;
 
 @Tag(name = "스와이프 액션 API", description = "카드 스와이프(좋아요/싫어요) 기록 및 좋아요 시 기본 보관함 자동 저장 API")
@@ -17,9 +19,9 @@ public interface ActiveLogApi {
 
     @Operation(summary = "카드 스와이프 평가 저장", description = "특정 카드에 대한 사용자의 액션을 기록합니다. (Like 시 덱에 자동 저장, 비회원은 API 호출 제외)")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공 (SAL20001)")
-    @ApiErrorExceptions({ActiveLogErrorCode.class})
+    @ApiErrorExceptions({ActiveLogErrorCode.class, CardErrorCode.class})
     ResponseEntity<ApiResponse<Void>> swipeCard(
-            @Parameter(description = "대상 카드 ID", in = ParameterIn.PATH) Long cardId,
+            @Parameter(description = "카드 공개 ID (publicId)", in = ParameterIn.PATH) UUID publicId,
             @RequestBody(description = "스와이프 요청 정보(LIKE/DISLIKE)") SwipeRequest request,
             @LoginUser Long userId);
 }

--- a/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogController.java
+++ b/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogController.java
@@ -4,13 +4,10 @@ import com.dekk.app.activelog.application.ActiveLogCommandService;
 import com.dekk.app.activelog.application.dto.command.SwipeCommand;
 import com.dekk.app.activelog.presentation.request.SwipeRequest;
 import com.dekk.app.activelog.presentation.response.ActiveLogResultCode;
-import com.dekk.app.card.application.CardQueryService;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.annotation.LoginUser;
 import jakarta.validation.Valid;
-
 import java.util.UUID;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -23,14 +20,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class ActiveLogController implements ActiveLogApi {
 
     private final ActiveLogCommandService activeLogCommandService;
-    private final CardQueryService cardQueryService;
 
     @Override
     @PostMapping("/w/v1/cards/{publicId}/swipe")
     public ResponseEntity<ApiResponse<Void>> swipeCard(
-            @PathVariable(name = "publicId") UUID publicId, @Valid @RequestBody SwipeRequest request, @LoginUser Long userId) {
-        Long cardId = cardQueryService.getCardIdByPublicId(publicId);
-        SwipeCommand command = new SwipeCommand(userId, cardId, request.swipeType());
+            @PathVariable(name = "publicId") UUID publicId,
+            @Valid @RequestBody SwipeRequest request,
+            @LoginUser Long userId) {
+        SwipeCommand command = new SwipeCommand(userId, publicId, request.swipeType());
         activeLogCommandService.saveSwipeAction(command);
 
         return ResponseEntity.ok(ApiResponse.from(ActiveLogResultCode.SWIPE_SUCCESS));

--- a/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogController.java
+++ b/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogController.java
@@ -4,9 +4,11 @@ import com.dekk.app.activelog.application.ActiveLogCommandService;
 import com.dekk.app.activelog.application.dto.command.SwipeCommand;
 import com.dekk.app.activelog.presentation.request.SwipeRequest;
 import com.dekk.app.activelog.presentation.response.ActiveLogResultCode;
+import com.dekk.app.card.application.CardQueryService;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.annotation.LoginUser;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,12 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class ActiveLogController implements ActiveLogApi {
 
     private final ActiveLogCommandService activeLogCommandService;
+    private final CardQueryService cardQueryService;
 
     @Override
-    @PostMapping("/w/v1/cards/{cardId}/swipe")
+    @PostMapping("/w/v1/cards/{publicId}/swipe")
     public ResponseEntity<ApiResponse<Void>> swipeCard(
-            @PathVariable("cardId") Long cardId, @Valid @RequestBody SwipeRequest request, @LoginUser Long userId) {
-
+            @PathVariable UUID publicId, @Valid @RequestBody SwipeRequest request, @LoginUser Long userId) {
+        Long cardId = cardQueryService.getCardIdByPublicId(publicId);
         SwipeCommand command = new SwipeCommand(userId, cardId, request.swipeType());
         activeLogCommandService.saveSwipeAction(command);
 

--- a/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogController.java
+++ b/src/main/java/com/dekk/app/activelog/presentation/controller/ActiveLogController.java
@@ -8,7 +8,9 @@ import com.dekk.app.card.application.CardQueryService;
 import com.dekk.global.response.ApiResponse;
 import com.dekk.global.security.annotation.LoginUser;
 import jakarta.validation.Valid;
+
 import java.util.UUID;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -26,7 +28,7 @@ public class ActiveLogController implements ActiveLogApi {
     @Override
     @PostMapping("/w/v1/cards/{publicId}/swipe")
     public ResponseEntity<ApiResponse<Void>> swipeCard(
-            @PathVariable UUID publicId, @Valid @RequestBody SwipeRequest request, @LoginUser Long userId) {
+            @PathVariable(name = "publicId") UUID publicId, @Valid @RequestBody SwipeRequest request, @LoginUser Long userId) {
         Long cardId = cardQueryService.getCardIdByPublicId(publicId);
         SwipeCommand command = new SwipeCommand(userId, cardId, request.swipeType());
         activeLogCommandService.saveSwipeAction(command);

--- a/src/main/java/com/dekk/app/card/application/CardQueryService.java
+++ b/src/main/java/com/dekk/app/card/application/CardQueryService.java
@@ -87,7 +87,7 @@ public class CardQueryService {
     public Optional<MemberCardResult> findByPublicId(UUID publicId) {
         return cardRepository.findByPublicId(publicId).map(MemberCardResult::from);
     }
-    
+
     public Optional<GuestCardResult> findByPublicIdForGuest(UUID publicId) {
         return cardRepository.findByPublicId(publicId).map(GuestCardResult::from);
     }
@@ -96,5 +96,5 @@ public class CardQueryService {
         return cardRepository
                 .findIdByPublicId(publicId)
                 .orElseThrow(() -> new CardBusinessException(CardErrorCode.CARD_NOT_FOUND));
-    
+    }
 }

--- a/src/main/java/com/dekk/app/card/application/CardQueryService.java
+++ b/src/main/java/com/dekk/app/card/application/CardQueryService.java
@@ -87,4 +87,11 @@ public class CardQueryService {
     public Optional<MemberCardResult> findByPublicId(UUID publicId) {
         return cardRepository.findByPublicId(publicId).map(MemberCardResult::from);
     }
+
+    public Long getCardIdByPublicId(UUID publicId) {
+        return cardRepository
+                .findByPublicId(publicId)
+                .map(Card::getId)
+                .orElseThrow(() -> new CardBusinessException(CardErrorCode.CARD_NOT_FOUND));
+    }
 }

--- a/src/main/java/com/dekk/app/card/application/CardQueryService.java
+++ b/src/main/java/com/dekk/app/card/application/CardQueryService.java
@@ -90,8 +90,7 @@ public class CardQueryService {
 
     public Long getCardIdByPublicId(UUID publicId) {
         return cardRepository
-                .findByPublicId(publicId)
-                .map(Card::getId)
+                .findIdByPublicId(publicId)
                 .orElseThrow(() -> new CardBusinessException(CardErrorCode.CARD_NOT_FOUND));
     }
 }

--- a/src/main/java/com/dekk/app/card/domain/repository/CardRepository.java
+++ b/src/main/java/com/dekk/app/card/domain/repository/CardRepository.java
@@ -41,4 +41,6 @@ public interface CardRepository {
     List<Card> findLatestApprovedCardsExcluding(Set<Long> excludeCardIds, int size);
 
     Optional<Card> findByPublicId(UUID publicId);
+
+    Optional<Long> findIdByPublicId(UUID publicId);
 }

--- a/src/main/java/com/dekk/app/card/infrastructure/CardRepositoryImpl.java
+++ b/src/main/java/com/dekk/app/card/infrastructure/CardRepositoryImpl.java
@@ -122,4 +122,9 @@ public class CardRepositoryImpl implements CardRepository {
     public Optional<Card> findByPublicId(UUID publicId) {
         return cardJpaRepository.findByPublicIdWithProducts(publicId);
     }
+
+    @Override
+    public Optional<Long> findIdByPublicId(UUID publicId) {
+        return cardJpaRepository.findIdByPublicId(publicId);
+    }
 }

--- a/src/main/java/com/dekk/app/card/infrastructure/jpa/CardJpaRepository.java
+++ b/src/main/java/com/dekk/app/card/infrastructure/jpa/CardJpaRepository.java
@@ -54,6 +54,9 @@ public interface CardJpaRepository extends JpaRepository<Card, Long>, JpaSpecifi
             + "WHERE c.publicId = :publicId AND c.status = 'APPROVED'")
     Optional<Card> findByPublicIdWithProducts(@Param("publicId") UUID publicId);
 
+    @Query("SELECT c.id FROM Card c WHERE c.publicId = :publicId")
+    Optional<Long> findIdByPublicId(@Param("publicId") UUID publicId);
+
     // TODO: approvedAt 정렬로 변경 필요
     @Query("SELECT c.id FROM Card c WHERE c.status = 'APPROVED' AND c.id NOT IN :excludeIds ORDER BY c.updatedAt DESC")
     List<Long> findLatestApprovedCardIdsExcluding(@Param("excludeIds") List<Long> excludeIds, Pageable pageable);


### PR DESCRIPTION
## #️⃣연관된 이슈

[DK-476](https://potenup-final.atlassian.net/browse/DK-476)

## 📝작업 내용
card_id → public_id 리팩토링 이후 스와이프 엔드포인트가 Long cardId를 요구해 UUID 전달 시 400 에러로 ActiveLog 미기록, 좋아요&싫어요 카드가 재노출되는 버그를 수정합니다.

- CardQueryService.getCardIdByPublicId(UUID) 추가 (APPROVED 카드가 없으면 CARD_NOT_FOUND 404)
- ActiveLogController에 CardQueryService 주입, publicId → cardId 변환 후 커맨드 생성
- ActiveLogApi 파라미터 타입 UUID로 변경, CardErrorCode 에러 명세 추가

[DK-476]: https://potenup-final.atlassian.net/browse/DK-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ