### PR TITLE
[FEAT] 백오피스 Zero-Trust 보안망 구축(#DK-480)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,6 +111,7 @@ dependencies {
     implementation 'me.paulschwarz:spring-dotenv:4.0.0'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
 
     // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/dekk/app/admin/application/AdminAuthService.java
+++ b/src/main/java/com/dekk/app/admin/application/AdminAuthService.java
@@ -5,17 +5,23 @@ import com.dekk.app.admin.application.dto.result.AdminLoginResult;
 import com.dekk.app.admin.domain.exception.AdminBusinessException;
 import com.dekk.app.admin.domain.exception.AdminErrorCode;
 import com.dekk.app.admin.domain.model.Admin;
+import com.dekk.app.admin.domain.model.AdminRefreshToken;
+import com.dekk.app.admin.domain.model.AdminStatus;
+import com.dekk.app.admin.domain.repository.AdminLoginRateLimiter;
+import com.dekk.app.admin.domain.repository.AdminRefreshTokenRepository;
 import com.dekk.app.admin.domain.repository.AdminRepository;
 import com.dekk.app.admin.domain.repository.AdminTokenBlackListRepository;
 import com.dekk.app.admin.security.AdminUserDetails;
 import com.dekk.global.security.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -25,34 +31,58 @@ public class AdminAuthService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final AdminTokenBlackListRepository adminTokenBlackListRepository;
+    private final AdminRefreshTokenRepository adminRefreshTokenRepository;
+    private final AdminLoginRateLimiter adminLoginRateLimiter;
 
+    @Transactional
     public AdminLoginResult login(AdminLoginCommand command) {
-        Admin admin = adminRepository
-                .findByEmail(command.email())
-                .orElseThrow(() -> new AdminBusinessException(AdminErrorCode.ADMIN_NOT_FOUND));
+
+        if (adminLoginRateLimiter.isLocked(command.ip(), command.email())) {
+            log.warn("[Security Alert] 잠긴 계정 로그인 시도 차단 - IP: {}, Email: {}", command.ip(), command.email());
+            throw new AdminBusinessException(AdminErrorCode.ACCOUNT_LOCKED);
+        }
+
+        Admin admin = adminRepository.findByEmail(command.email()).orElseThrow(() -> {
+            adminLoginRateLimiter.incrementFailCount(command.ip(), command.email());
+            return new AdminBusinessException(AdminErrorCode.ADMIN_NOT_FOUND);
+        });
 
         if (!passwordEncoder.matches(command.password(), admin.getPassword())) {
+            adminLoginRateLimiter.incrementFailCount(command.ip(), command.email());
             throw new AdminBusinessException(AdminErrorCode.INVALID_PASSWORD);
         }
 
-        AdminUserDetails userDetails = new AdminUserDetails(
-                admin.getId(), admin.getEmail(), admin.getAdminRole().getKey());
-
-        Authentication authentication =
-                new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-        String accessToken = jwtTokenProvider.createAccessToken(authentication);
-
-        return new AdminLoginResult(accessToken);
-    }
-
-    public void logout(String accessToken) {
-        if (accessToken == null || accessToken.isBlank()) {
-            return;
+        if (admin.getStatus() == AdminStatus.SUSPENDED) {
+            throw new AdminBusinessException(AdminErrorCode.ACCOUNT_SUSPENDED);
         }
 
-        long ttlSeconds = jwtTokenProvider.getRemainingExpiration(accessToken);
-        if (ttlSeconds > 0) {
-            adminTokenBlackListRepository.save(accessToken, ttlSeconds);
+        adminLoginRateLimiter.resetFailCount(command.ip(), command.email());
+
+        adminRefreshTokenRepository.deleteByAdminId(admin.getId());
+
+        AdminUserDetails userDetails = new AdminUserDetails(
+                admin.getId(), admin.getEmail(), admin.getAdminRole().getKey());
+        Authentication auth = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+        String accessToken = jwtTokenProvider.createAccessToken(auth);
+        String refreshToken = jwtTokenProvider.createRefreshToken(auth);
+
+        adminRefreshTokenRepository.save(AdminRefreshToken.create(admin.getId(), refreshToken));
+
+        log.info("[Admin Login] AdminId: {} 로그인 성공.", admin.getId());
+        return new AdminLoginResult(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public void logout(String accessToken, Long adminId) {
+        if (accessToken != null && !accessToken.isBlank()) {
+            long ttlSeconds = jwtTokenProvider.getRemainingExpiration(accessToken);
+            if (ttlSeconds > 0) {
+                adminTokenBlackListRepository.save(accessToken, ttlSeconds);
+            }
+        }
+        if (adminId != null) {
+            adminRefreshTokenRepository.deleteByAdminId(adminId);
         }
     }
 }

--- a/src/main/java/com/dekk/app/admin/application/AdminCommandService.java
+++ b/src/main/java/com/dekk/app/admin/application/AdminCommandService.java
@@ -6,6 +6,7 @@ import com.dekk.app.admin.domain.exception.AdminBusinessException;
 import com.dekk.app.admin.domain.exception.AdminErrorCode;
 import com.dekk.app.admin.domain.model.Admin;
 import com.dekk.app.admin.domain.model.AdminRole;
+import com.dekk.app.admin.domain.model.AdminStatus;
 import com.dekk.app.admin.domain.repository.AdminRefreshTokenRepository;
 import com.dekk.app.admin.domain.repository.AdminRepository;
 import com.dekk.app.admin.domain.repository.AdminTokenBlackListRepository;
@@ -14,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -51,35 +53,70 @@ public class AdminCommandService {
         adminEmailService.sendInviteEmail(command.email(), token);
 
         log.info("[Audit] 관리자 초대 토큰 발행. InviterId: {}, Email: {}, IP: {}", inviterId, command.email(), clientIp);
-        log.info("[테스트용 임시 토큰 발급] Token: {}", token);
     }
 
     public void completeSignup(AdminSignupCommand command, String clientIp) {
-        String data = redisTemplate.opsForValue().get(INVITE_PREFIX + command.token());
+        String data = redisTemplate.opsForValue().getAndDelete(INVITE_PREFIX + command.token());
         if (data == null) {
             throw new AdminBusinessException(AdminErrorCode.INVALID_INVITE_TOKEN);
         }
 
         String[] parts = data.split(":");
+        if (parts.length != 3) {
+            throw new AdminBusinessException(AdminErrorCode.INVALID_INVITE_TOKEN);
+        }
+
         String email = parts[0];
-        AdminRole role = AdminRole.valueOf(parts[1]);
+        AdminRole role;
+        try {
+            role = AdminRole.valueOf(parts[1]);
+        } catch (IllegalArgumentException e) {
+            throw new AdminBusinessException(AdminErrorCode.INVALID_INVITE_TOKEN);
+        }
+
+        if (adminRepository.existsByEmail(email)) {
+            throw new AdminBusinessException(AdminErrorCode.DUPLICATE_EMAIL);
+        }
 
         Admin admin = Admin.create(email, passwordEncoder.encode(command.password()), role, command.department());
-        adminRepository.save(admin);
+        try {
+            adminRepository.saveAndFlush(admin);
+        } catch (DataIntegrityViolationException e) {
+            throw new AdminBusinessException(AdminErrorCode.DUPLICATE_EMAIL);
+        }
 
-        redisTemplate.delete(INVITE_PREFIX + command.token());
         log.info("[Audit] 신규 관리자 가입 완료. AdminId: {}, IP: {}", admin.getId(), clientIp);
     }
 
     public void suspendAdmin(Long suspenderId, Long targetId, String clientIp) {
+        if (targetId != null && targetId.equals(suspenderId)) {
+            throw new AdminBusinessException(AdminErrorCode.CANNOT_SUSPEND_SELF);
+        }
+
         Admin admin = adminRepository
                 .findById(targetId)
                 .orElseThrow(() -> new AdminBusinessException(AdminErrorCode.ADMIN_NOT_FOUND));
 
+        if (isLastActiveSuperAdmin(admin)) {
+            throw new AdminBusinessException(AdminErrorCode.LAST_SUPER_ADMIN_CANNOT_BE_SUSPENDED);
+        }
+
         admin.suspend();
         adminRefreshTokenRepository.deleteByAdminId(targetId);
-        adminTokenBlackListRepository.saveKickOut(targetId, adminAtValidityTime);
+        if (!adminTokenBlackListRepository.saveKickOut(targetId, adminAtValidityTime)) {
+            throw new AdminBusinessException(AdminErrorCode.KICKOUT_REGISTRATION_FAILED);
+        }
 
-        log.warn("[Audit] 관리자 강제 정지(Kill-Switch). TargetId: {}, IP: {}", targetId, clientIp);
+        log.warn(
+                "[Audit] 관리자 강제 정지(Kill-Switch). SuspenderId: {}, TargetId: {}, IP: {}",
+                suspenderId,
+                targetId,
+                clientIp);
+    }
+
+    private boolean isLastActiveSuperAdmin(Admin admin) {
+        return admin.getAdminRole() == AdminRole.SUPER_ADMIN
+                && admin.getStatus() == AdminStatus.ACTIVE
+                && adminRepository.countByAdminRoleAndStatus(AdminRole.SUPER_ADMIN, AdminStatus.ACTIVE) <= 1;
     }
 }

--- a/src/main/java/com/dekk/app/admin/application/AdminCommandService.java
+++ b/src/main/java/com/dekk/app/admin/application/AdminCommandService.java
@@ -1,0 +1,87 @@
+package com.dekk.app.admin.application;
+
+import com.dekk.app.admin.application.dto.command.AdminInviteCommand;
+import com.dekk.app.admin.application.dto.command.AdminSignupCommand;
+import com.dekk.app.admin.domain.exception.AdminBusinessException;
+import com.dekk.app.admin.domain.exception.AdminErrorCode;
+import com.dekk.app.admin.domain.model.Admin;
+import com.dekk.app.admin.domain.model.AdminRole;
+import com.dekk.app.admin.domain.repository.AdminRefreshTokenRepository;
+import com.dekk.app.admin.domain.repository.AdminRepository;
+import com.dekk.app.admin.domain.repository.AdminTokenBlackListRepository;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminCommandService {
+
+    private static final String INVITE_PREFIX = "ADMIN:INVITE:";
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final AdminRepository adminRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final AdminRefreshTokenRepository adminRefreshTokenRepository;
+    private final AdminTokenBlackListRepository adminTokenBlackListRepository;
+    private final AdminEmailService adminEmailService;
+
+    @Value("${jwt.admin-access-token-validity-in-seconds}")
+    private long adminAtValidityTime;
+
+    public void inviteAdmin(Long inviterId, AdminInviteCommand command, String clientIp) {
+        if (adminRepository.existsByEmail(command.email())) {
+            throw new AdminBusinessException(AdminErrorCode.DUPLICATE_EMAIL);
+        }
+
+        String token = UUID.randomUUID().toString().replace("-", "");
+        String payload = String.format("%s:%s:%d", command.email(), command.role().name(), inviterId);
+
+        redisTemplate.opsForValue().set(INVITE_PREFIX + token, payload, 24, TimeUnit.HOURS);
+
+        adminEmailService.sendInviteEmail(command.email(), token);
+
+        log.info("[Audit] 관리자 초대 토큰 발행. InviterId: {}, Email: {}, IP: {}", inviterId, command.email(), clientIp);
+        log.info("[테스트용 임시 토큰 발급] Token: {}", token);
+    }
+
+
+    public void completeSignup(AdminSignupCommand command, String clientIp) {
+        String data = redisTemplate.opsForValue().get(INVITE_PREFIX + command.token());
+        if (data == null) {
+            throw new AdminBusinessException(AdminErrorCode.INVALID_INVITE_TOKEN);
+        }
+
+        String[] parts = data.split(":");
+        String email = parts[0];
+        AdminRole role = AdminRole.valueOf(parts[1]);
+
+        Admin admin = Admin.create(email, passwordEncoder.encode(command.password()), role, command.department());
+        adminRepository.save(admin);
+
+        redisTemplate.delete(INVITE_PREFIX + command.token());
+        log.info("[Audit] 신규 관리자 가입 완료. AdminId: {}, IP: {}", admin.getId(), clientIp);
+    }
+
+    public void suspendAdmin(Long suspenderId, Long targetId, String clientIp) {
+        Admin admin = adminRepository
+            .findById(targetId)
+            .orElseThrow(() -> new AdminBusinessException(AdminErrorCode.ADMIN_NOT_FOUND));
+
+        admin.suspend();
+        adminRefreshTokenRepository.deleteByAdminId(targetId);
+        adminTokenBlackListRepository.saveKickOut(targetId, adminAtValidityTime);
+
+        log.warn("[Audit] 관리자 강제 정지(Kill-Switch). TargetId: {}, IP: {}", targetId, clientIp);
+    }
+}

--- a/src/main/java/com/dekk/app/admin/application/AdminCommandService.java
+++ b/src/main/java/com/dekk/app/admin/application/AdminCommandService.java
@@ -9,10 +9,8 @@ import com.dekk.app.admin.domain.model.AdminRole;
 import com.dekk.app.admin.domain.repository.AdminRefreshTokenRepository;
 import com.dekk.app.admin.domain.repository.AdminRepository;
 import com.dekk.app.admin.domain.repository.AdminTokenBlackListRepository;
-
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -45,7 +43,8 @@ public class AdminCommandService {
         }
 
         String token = UUID.randomUUID().toString().replace("-", "");
-        String payload = String.format("%s:%s:%d", command.email(), command.role().name(), inviterId);
+        String payload =
+                String.format("%s:%s:%d", command.email(), command.role().name(), inviterId);
 
         redisTemplate.opsForValue().set(INVITE_PREFIX + token, payload, 24, TimeUnit.HOURS);
 
@@ -54,7 +53,6 @@ public class AdminCommandService {
         log.info("[Audit] 관리자 초대 토큰 발행. InviterId: {}, Email: {}, IP: {}", inviterId, command.email(), clientIp);
         log.info("[테스트용 임시 토큰 발급] Token: {}", token);
     }
-
 
     public void completeSignup(AdminSignupCommand command, String clientIp) {
         String data = redisTemplate.opsForValue().get(INVITE_PREFIX + command.token());
@@ -75,8 +73,8 @@ public class AdminCommandService {
 
     public void suspendAdmin(Long suspenderId, Long targetId, String clientIp) {
         Admin admin = adminRepository
-            .findById(targetId)
-            .orElseThrow(() -> new AdminBusinessException(AdminErrorCode.ADMIN_NOT_FOUND));
+                .findById(targetId)
+                .orElseThrow(() -> new AdminBusinessException(AdminErrorCode.ADMIN_NOT_FOUND));
 
         admin.suspend();
         adminRefreshTokenRepository.deleteByAdminId(targetId);

--- a/src/main/java/com/dekk/app/admin/application/AdminEmailService.java
+++ b/src/main/java/com/dekk/app/admin/application/AdminEmailService.java
@@ -28,11 +28,10 @@ public class AdminEmailService {
 
             String inviteUrl = "https://space.dekk.co.kr/signup?token=" + inviteToken;
 
-            message.setText("안녕하세요.\n\n" +
-                "DEKK 백오피스 관리자로 초대되었습니다.\n" +
-                "아래 링크를 클릭하여 비밀번호 및 소속을 입력하고 가입을 완료해 주세요.\n\n" +
-                inviteUrl + "\n\n" +
-                "※ 본 링크는 24시간 동안만 유효합니다.");
+            message.setText("안녕하세요.\n\n" + "DEKK 백오피스 관리자로 초대되었습니다.\n"
+                    + "아래 링크를 클릭하여 비밀번호 및 소속을 입력하고 가입을 완료해 주세요.\n\n"
+                    + inviteUrl
+                    + "\n\n" + "※ 본 링크는 24시간 동안만 유효합니다.");
 
             mailSender.send(message);
             log.info("[AdminEmailService] 초대 메일 발송 완료. To: {}", toEmail);

--- a/src/main/java/com/dekk/app/admin/application/AdminEmailService.java
+++ b/src/main/java/com/dekk/app/admin/application/AdminEmailService.java
@@ -1,0 +1,44 @@
+package com.dekk.app.admin.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdminEmailService {
+
+    private final JavaMailSender mailSender;
+
+    @Value("${spring.mail.username}")
+    private String fromEmail;
+
+    @Async
+    public void sendInviteEmail(String toEmail, String inviteToken) {
+        try {
+            SimpleMailMessage message = new SimpleMailMessage();
+            message.setFrom(fromEmail);
+            message.setTo(toEmail);
+            message.setSubject("[DEKK] 백오피스 관리자 계정 초대");
+
+            String inviteUrl = "https://space.dekk.co.kr/signup?token=" + inviteToken;
+
+            message.setText("안녕하세요.\n\n" +
+                "DEKK 백오피스 관리자로 초대되었습니다.\n" +
+                "아래 링크를 클릭하여 비밀번호 및 소속을 입력하고 가입을 완료해 주세요.\n\n" +
+                inviteUrl + "\n\n" +
+                "※ 본 링크는 24시간 동안만 유효합니다.");
+
+            mailSender.send(message);
+            log.info("[AdminEmailService] 초대 메일 발송 완료. To: {}", toEmail);
+
+        } catch (Exception e) {
+            log.error("[AdminEmailService] 초대 메일 발송 실패. To: {}", toEmail, e);
+        }
+    }
+}

--- a/src/main/java/com/dekk/app/admin/application/dto/command/AdminInviteCommand.java
+++ b/src/main/java/com/dekk/app/admin/application/dto/command/AdminInviteCommand.java
@@ -1,0 +1,5 @@
+package com.dekk.app.admin.application.dto.command;
+
+import com.dekk.app.admin.domain.model.AdminRole;
+
+public record AdminInviteCommand(String email, AdminRole role) {}

--- a/src/main/java/com/dekk/app/admin/application/dto/command/AdminLoginCommand.java
+++ b/src/main/java/com/dekk/app/admin/application/dto/command/AdminLoginCommand.java
@@ -1,3 +1,3 @@
 package com.dekk.app.admin.application.dto.command;
 
-public record AdminLoginCommand(String email, String password) {}
+public record AdminLoginCommand(String email, String password, String ip) {}

--- a/src/main/java/com/dekk/app/admin/application/dto/command/AdminSignupCommand.java
+++ b/src/main/java/com/dekk/app/admin/application/dto/command/AdminSignupCommand.java
@@ -1,0 +1,3 @@
+package com.dekk.app.admin.application.dto.command;
+
+public record AdminSignupCommand(String token, String password, String department) {}

--- a/src/main/java/com/dekk/app/admin/application/dto/result/AdminLoginResult.java
+++ b/src/main/java/com/dekk/app/admin/application/dto/result/AdminLoginResult.java
@@ -1,3 +1,3 @@
 package com.dekk.app.admin.application.dto.result;
 
-public record AdminLoginResult(String accessToken) {}
+public record AdminLoginResult(String accessToken, String refreshToken) {}

--- a/src/main/java/com/dekk/app/admin/domain/exception/AdminErrorCode.java
+++ b/src/main/java/com/dekk/app/admin/domain/exception/AdminErrorCode.java
@@ -7,16 +7,15 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AdminErrorCode implements ErrorCode {
     INVALID_ADMIN_DATA(HttpStatus.BAD_REQUEST, "EAD40001", "관리자 필수 정보가 누락되었거나 올바르지 않습니다."),
-
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "EAD40101", "비밀번호가 일치하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "EAD40102", "유효하지 않은 관리자 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EAD40103", "만료된 관리자 토큰입니다."),
     BLACKLISTED_TOKEN(HttpStatus.UNAUTHORIZED, "EAD40104", "로그아웃 처리되어 무효화된 토큰입니다."),
-
+    INVALID_INVITE_TOKEN(HttpStatus.UNAUTHORIZED, "EAD40105", "유효하지 않거나 만료된 초대 토큰입니다."),
     UNAUTHORIZED_ROLE(HttpStatus.FORBIDDEN, "EAD40301", "권한이 없습니다."),
-
+    ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "EAD40302", "로그인 실패 5회 누적으로 30분간 계정이 잠겼습니다."),
+    ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "EAD40303", "관리자에 의해 정지된 계정입니다."),
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "EAD40401", "관리자를 찾을 수 없습니다."),
-
     DUPLICATE_EMAIL(HttpStatus.CONFLICT, "EAD40901", "이미 등록된 이메일입니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/dekk/app/admin/domain/exception/AdminErrorCode.java
+++ b/src/main/java/com/dekk/app/admin/domain/exception/AdminErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AdminErrorCode implements ErrorCode {
     INVALID_ADMIN_DATA(HttpStatus.BAD_REQUEST, "EAD40001", "관리자 필수 정보가 누락되었거나 올바르지 않습니다."),
+    CANNOT_SUSPEND_SELF(HttpStatus.BAD_REQUEST, "EAD40002", "자기 자신의 관리자 계정은 정지할 수 없습니다."),
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "EAD40101", "비밀번호가 일치하지 않습니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "EAD40102", "유효하지 않은 관리자 토큰입니다."),
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "EAD40103", "만료된 관리자 토큰입니다."),
@@ -16,7 +17,9 @@ public enum AdminErrorCode implements ErrorCode {
     ACCOUNT_LOCKED(HttpStatus.FORBIDDEN, "EAD40302", "로그인 실패 5회 누적으로 30분간 계정이 잠겼습니다."),
     ACCOUNT_SUSPENDED(HttpStatus.FORBIDDEN, "EAD40303", "관리자에 의해 정지된 계정입니다."),
     ADMIN_NOT_FOUND(HttpStatus.NOT_FOUND, "EAD40401", "관리자를 찾을 수 없습니다."),
-    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "EAD40901", "이미 등록된 이메일입니다.");
+    DUPLICATE_EMAIL(HttpStatus.CONFLICT, "EAD40901", "이미 등록된 이메일입니다."),
+    LAST_SUPER_ADMIN_CANNOT_BE_SUSPENDED(HttpStatus.CONFLICT, "EAD40902", "마지막 활성 슈퍼 관리자 계정은 정지할 수 없습니다."),
+    KICKOUT_REGISTRATION_FAILED(HttpStatus.SERVICE_UNAVAILABLE, "EAD50301", "관리자 즉시 차단 처리에 실패했습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/dekk/app/admin/domain/model/Admin.java
+++ b/src/main/java/com/dekk/app/admin/domain/model/Admin.java
@@ -3,6 +3,7 @@ package com.dekk.app.admin.domain.model;
 import com.dekk.app.admin.domain.exception.AdminBusinessException;
 import com.dekk.app.admin.domain.exception.AdminErrorCode;
 import com.dekk.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -31,32 +32,49 @@ public class Admin extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
     private String email;
 
+    @Column(nullable = false)
     private String password;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private AdminRole adminRole;
 
-    private Admin(String email, String password, AdminRole adminRole) {
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AdminStatus status;
+
+    @Column(nullable = false, length = 100)
+    private String department;
+
+    private Admin(String email, String password, AdminRole adminRole, String department) {
         this.email = email;
         this.password = password;
         this.adminRole = adminRole;
+        this.status = AdminStatus.ACTIVE;
+        this.department = department;
     }
 
-    public static Admin create(String email, String encodedPassword, AdminRole adminRole) {
+    public static Admin create(String email, String encodedPassword, AdminRole adminRole, String department) {
         validate(email, encodedPassword, adminRole);
-        return new Admin(email, encodedPassword, adminRole);
+        if (department == null || department.isBlank()) {
+            throw new AdminBusinessException(AdminErrorCode.INVALID_ADMIN_DATA);
+        }
+        return new Admin(email, encodedPassword, adminRole, department);
+    }
+
+    public void suspend() {
+        this.status = AdminStatus.SUSPENDED;
     }
 
     private static void validate(String email, String encodedPassword, AdminRole adminRole) {
-        if (email == null || email.isBlank()) {
-            throw new AdminBusinessException(AdminErrorCode.INVALID_ADMIN_DATA);
-        }
-        if (encodedPassword == null || encodedPassword.isBlank()) {
-            throw new AdminBusinessException(AdminErrorCode.INVALID_ADMIN_DATA);
-        }
-        if (adminRole == null) {
+        if (email == null
+                || email.isBlank()
+                || encodedPassword == null
+                || encodedPassword.isBlank()
+                || adminRole == null) {
             throw new AdminBusinessException(AdminErrorCode.INVALID_ADMIN_DATA);
         }
     }

--- a/src/main/java/com/dekk/app/admin/domain/model/AdminRefreshToken.java
+++ b/src/main/java/com/dekk/app/admin/domain/model/AdminRefreshToken.java
@@ -1,0 +1,26 @@
+package com.dekk.app.admin.domain.model;
+
+import com.dekk.app.admin.domain.exception.AdminBusinessException;
+import com.dekk.app.admin.domain.exception.AdminErrorCode;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminRefreshToken {
+    private Long adminId;
+    private String token;
+
+    private AdminRefreshToken(Long adminId, String token) {
+        this.adminId = adminId;
+        this.token = token;
+    }
+
+    public static AdminRefreshToken create(Long adminId, String token) {
+        if (adminId == null || token == null || token.isBlank()) {
+            throw new AdminBusinessException(AdminErrorCode.INVALID_TOKEN);
+        }
+        return new AdminRefreshToken(adminId, token);
+    }
+}

--- a/src/main/java/com/dekk/app/admin/domain/model/AdminStatus.java
+++ b/src/main/java/com/dekk/app/admin/domain/model/AdminStatus.java
@@ -1,0 +1,6 @@
+package com.dekk.app.admin.domain.model;
+
+public enum AdminStatus {
+    ACTIVE,
+    SUSPENDED
+}

--- a/src/main/java/com/dekk/app/admin/domain/repository/AdminLoginRateLimiter.java
+++ b/src/main/java/com/dekk/app/admin/domain/repository/AdminLoginRateLimiter.java
@@ -1,0 +1,9 @@
+package com.dekk.app.admin.domain.repository;
+
+public interface AdminLoginRateLimiter {
+    boolean isLocked(String ip, String email);
+
+    void incrementFailCount(String ip, String email);
+
+    void resetFailCount(String ip, String email);
+}

--- a/src/main/java/com/dekk/app/admin/domain/repository/AdminRefreshTokenRepository.java
+++ b/src/main/java/com/dekk/app/admin/domain/repository/AdminRefreshTokenRepository.java
@@ -1,0 +1,9 @@
+package com.dekk.app.admin.domain.repository;
+
+import com.dekk.app.admin.domain.model.AdminRefreshToken;
+
+public interface AdminRefreshTokenRepository {
+    void save(AdminRefreshToken refreshToken);
+
+    void deleteByAdminId(Long adminId);
+}

--- a/src/main/java/com/dekk/app/admin/domain/repository/AdminRepository.java
+++ b/src/main/java/com/dekk/app/admin/domain/repository/AdminRepository.java
@@ -1,14 +1,20 @@
 package com.dekk.app.admin.domain.repository;
 
 import com.dekk.app.admin.domain.model.Admin;
+import com.dekk.app.admin.domain.model.AdminRole;
+import com.dekk.app.admin.domain.model.AdminStatus;
 import java.util.Optional;
 
 public interface AdminRepository {
     Admin save(Admin admin);
+
+    Admin saveAndFlush(Admin admin);
 
     Optional<Admin> findByEmail(String email);
 
     boolean existsByEmail(String email);
 
     Optional<Admin> findById(Long id);
+
+    long countByAdminRoleAndStatus(AdminRole adminRole, AdminStatus status);
 }

--- a/src/main/java/com/dekk/app/admin/domain/repository/AdminTokenBlackListRepository.java
+++ b/src/main/java/com/dekk/app/admin/domain/repository/AdminTokenBlackListRepository.java
@@ -5,7 +5,7 @@ public interface AdminTokenBlackListRepository {
 
     boolean isBlacklisted(String accessToken);
 
-    void saveKickOut(Long adminId, long ttlSeconds);
+    boolean saveKickOut(Long adminId, long ttlSeconds);
 
     boolean isKickedOut(Long adminId);
 }

--- a/src/main/java/com/dekk/app/admin/domain/repository/AdminTokenBlackListRepository.java
+++ b/src/main/java/com/dekk/app/admin/domain/repository/AdminTokenBlackListRepository.java
@@ -1,6 +1,11 @@
 package com.dekk.app.admin.domain.repository;
 
 public interface AdminTokenBlackListRepository {
-
     void save(String accessToken, long ttlSeconds);
+
+    boolean isBlacklisted(String accessToken);
+
+    void saveKickOut(Long adminId, long ttlSeconds);
+
+    boolean isKickedOut(Long adminId);
 }

--- a/src/main/java/com/dekk/app/admin/infrastructure/AdminRepositoryImpl.java
+++ b/src/main/java/com/dekk/app/admin/infrastructure/AdminRepositoryImpl.java
@@ -1,6 +1,8 @@
 package com.dekk.app.admin.infrastructure;
 
 import com.dekk.app.admin.domain.model.Admin;
+import com.dekk.app.admin.domain.model.AdminRole;
+import com.dekk.app.admin.domain.model.AdminStatus;
 import com.dekk.app.admin.domain.repository.AdminRepository;
 import com.dekk.app.admin.infrastructure.jpa.AdminJpaRepository;
 import java.util.Optional;
@@ -19,6 +21,11 @@ public class AdminRepositoryImpl implements AdminRepository {
     }
 
     @Override
+    public Admin saveAndFlush(Admin admin) {
+        return adminJpaRepository.saveAndFlush(admin);
+    }
+
+    @Override
     public Optional<Admin> findByEmail(String email) {
         return adminJpaRepository.findByEmail(email);
     }
@@ -31,5 +38,10 @@ public class AdminRepositoryImpl implements AdminRepository {
     @Override
     public Optional<Admin> findById(Long id) {
         return adminJpaRepository.findById(id);
+    }
+
+    @Override
+    public long countByAdminRoleAndStatus(AdminRole adminRole, AdminStatus status) {
+        return adminJpaRepository.countByAdminRoleAndStatus(adminRole, status);
     }
 }

--- a/src/main/java/com/dekk/app/admin/infrastructure/jpa/AdminJpaRepository.java
+++ b/src/main/java/com/dekk/app/admin/infrastructure/jpa/AdminJpaRepository.java
@@ -1,6 +1,8 @@
 package com.dekk.app.admin.infrastructure.jpa;
 
 import com.dekk.app.admin.domain.model.Admin;
+import com.dekk.app.admin.domain.model.AdminRole;
+import com.dekk.app.admin.domain.model.AdminStatus;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +10,6 @@ public interface AdminJpaRepository extends JpaRepository<Admin, Long> {
     Optional<Admin> findByEmail(String email);
 
     boolean existsByEmail(String email);
+
+    long countByAdminRoleAndStatus(AdminRole adminRole, AdminStatus status);
 }

--- a/src/main/java/com/dekk/app/admin/infrastructure/redis/AdminLoginRateLimiterRedisImpl.java
+++ b/src/main/java/com/dekk/app/admin/infrastructure/redis/AdminLoginRateLimiterRedisImpl.java
@@ -1,0 +1,61 @@
+package com.dekk.app.admin.infrastructure.redis;
+
+import com.dekk.app.admin.domain.repository.AdminLoginRateLimiter;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class AdminLoginRateLimiterRedisImpl implements AdminLoginRateLimiter {
+    private final RedisTemplate<String, String> redisTemplate;
+
+    private static final String PREFIX = "LOGIN_FAIL:";
+    private static final int MAX_FAIL_COUNT = 5;
+    private static final long LOCK_TIME_MINUTES = 30;
+    private static final long TRACKING_TIME_MINUTES = 5;
+
+    private String generateKey(String ip, String email) {
+        return PREFIX + ip + ":" + email;
+    }
+
+    @Override
+    public boolean isLocked(String ip, String email) {
+        try {
+            String countStr = redisTemplate.opsForValue().get(generateKey(ip, email));
+            return countStr != null && Integer.parseInt(countStr) >= MAX_FAIL_COUNT;
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] 어드민 로그인 잠금 상태 조회 실패", e);
+            return false;
+        }
+    }
+
+    @Override
+    public void incrementFailCount(String ip, String email) {
+        try {
+            String key = generateKey(ip, email);
+            Long currentCount = redisTemplate.opsForValue().increment(key);
+
+            if (currentCount != null && currentCount >= MAX_FAIL_COUNT) {
+                redisTemplate.expire(key, LOCK_TIME_MINUTES, TimeUnit.MINUTES);
+                log.warn("[Admin Lockout] 어드민 계정 잠금 처리됨 - IP: {}, Email: {}", ip, email);
+            } else if (currentCount != null && currentCount == 1) {
+                redisTemplate.expire(key, TRACKING_TIME_MINUTES, TimeUnit.MINUTES);
+            }
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] 어드민 로그인 실패 카운트 증가 실패", e);
+        }
+    }
+
+    @Override
+    public void resetFailCount(String ip, String email) {
+        try {
+            redisTemplate.delete(generateKey(ip, email));
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] 어드민 로그인 실패 카운트 초기화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/dekk/app/admin/infrastructure/redis/AdminRefreshTokenRedisRepositoryImpl.java
+++ b/src/main/java/com/dekk/app/admin/infrastructure/redis/AdminRefreshTokenRedisRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.dekk.app.admin.infrastructure.redis;
+
+import com.dekk.app.admin.domain.model.AdminRefreshToken;
+import com.dekk.app.admin.domain.repository.AdminRefreshTokenRepository;
+import java.util.concurrent.TimeUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+@Slf4j
+@Repository
+@RequiredArgsConstructor
+public class AdminRefreshTokenRedisRepositoryImpl implements AdminRefreshTokenRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String PREFIX = "RT:ADMIN:";
+
+    @Value("${jwt.admin-refresh-token-validity-in-seconds}")
+    private long refreshTokenTtlSeconds;
+
+    @Override
+    public void save(AdminRefreshToken refreshToken) {
+        String key = PREFIX + refreshToken.getAdminId();
+        try {
+            redisTemplate.opsForValue().set(key, refreshToken.getToken(), refreshTokenTtlSeconds, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] 어드민 Refresh Token 저장 실패 - AdminId: {}", refreshToken.getAdminId(), e);
+        }
+    }
+
+    @Override
+    public void deleteByAdminId(Long adminId) {
+        String key = PREFIX + adminId;
+        try {
+            redisTemplate.delete(key);
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] 어드민 Refresh Token 삭제 실패 - AdminId: {}", adminId, e);
+        }
+    }
+}

--- a/src/main/java/com/dekk/app/admin/infrastructure/redis/AdminTokenBlackListRedisRepositoryImpl.java
+++ b/src/main/java/com/dekk/app/admin/infrastructure/redis/AdminTokenBlackListRedisRepositoryImpl.java
@@ -42,12 +42,14 @@ public class AdminTokenBlackListRedisRepositoryImpl implements AdminTokenBlackLi
     }
 
     @Override
-    public void saveKickOut(Long adminId, long ttlSeconds) {
-        if (adminId == null || ttlSeconds <= 0) return;
+    public boolean saveKickOut(Long adminId, long ttlSeconds) {
+        if (adminId == null || ttlSeconds <= 0) return false;
         try {
             redisTemplate.opsForValue().set(KICKOUT_PREFIX + adminId, "kicked_out", ttlSeconds, TimeUnit.SECONDS);
+            return true;
         } catch (Exception e) {
             log.error("[Redis Fail-Safe] 강제 킥아웃 수배령 저장 실패 - AdminId: {}", adminId, e);
+            return false;
         }
     }
 

--- a/src/main/java/com/dekk/app/admin/infrastructure/redis/AdminTokenBlackListRedisRepositoryImpl.java
+++ b/src/main/java/com/dekk/app/admin/infrastructure/redis/AdminTokenBlackListRedisRepositoryImpl.java
@@ -1,7 +1,6 @@
 package com.dekk.app.admin.infrastructure.redis;
 
 import com.dekk.app.admin.domain.repository.AdminTokenBlackListRepository;
-import com.dekk.global.security.jwt.TokenBlacklistManager;
 import com.dekk.global.security.util.SecurityUtils;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
@@ -12,37 +11,53 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @Repository
 @RequiredArgsConstructor
-public class AdminTokenBlackListRedisRepositoryImpl implements AdminTokenBlackListRepository, TokenBlacklistManager {
+public class AdminTokenBlackListRedisRepositoryImpl implements AdminTokenBlackListRepository {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    private static final String PREFIX = "BL:ADMIN:";
-    private static final String BLACKLIST_VALUE = "logout";
+    private static final String AT_PREFIX = "BL:ADMIN:";
+    private static final String KICKOUT_PREFIX = "BL:ADMIN_KICK:";
 
     @Override
     public void save(String accessToken, long ttlSeconds) {
-        if (accessToken == null || accessToken.isBlank() || ttlSeconds <= 0) {
-            return;
-        }
-
-        String key = PREFIX + SecurityUtils.hashToken(accessToken);
+        if (accessToken == null || accessToken.isBlank() || ttlSeconds <= 0) return;
+        String key = AT_PREFIX + SecurityUtils.hashToken(accessToken);
         try {
-            redisTemplate.opsForValue().set(key, BLACKLIST_VALUE, ttlSeconds, TimeUnit.SECONDS);
+            redisTemplate.opsForValue().set(key, "logout", ttlSeconds, TimeUnit.SECONDS);
         } catch (Exception e) {
-            log.error("[Redis Fail-Safe] 어드민 토큰 블랙리스트 저장 실패", e);
+            log.error("[Redis Fail-Safe] 토큰 블랙리스트 저장 실패", e);
         }
     }
 
     @Override
     public boolean isBlacklisted(String accessToken) {
-        if (accessToken == null || accessToken.isBlank()) {
-            return true;
-        }
-        String key = PREFIX + SecurityUtils.hashToken(accessToken);
+        if (accessToken == null || accessToken.isBlank()) return true;
+        String key = AT_PREFIX + SecurityUtils.hashToken(accessToken);
         try {
             return Boolean.TRUE.equals(redisTemplate.hasKey(key));
         } catch (Exception e) {
-            log.error("[Redis Fail-Safe] 어드민 토큰 블랙리스트 조회 실패. 보안을 위해 접근을 차단(Fail-Close)합니다.", e);
+            log.error("[Redis Fail-Safe] 블랙리스트 조회 실패 (Fail-Close)", e);
+            return true;
+        }
+    }
+
+    @Override
+    public void saveKickOut(Long adminId, long ttlSeconds) {
+        if (adminId == null || ttlSeconds <= 0) return;
+        try {
+            redisTemplate.opsForValue().set(KICKOUT_PREFIX + adminId, "kicked_out", ttlSeconds, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] 강제 킥아웃 수배령 저장 실패 - AdminId: {}", adminId, e);
+        }
+    }
+
+    @Override
+    public boolean isKickedOut(Long adminId) {
+        if (adminId == null) return true;
+        try {
+            return Boolean.TRUE.equals(redisTemplate.hasKey(KICKOUT_PREFIX + adminId));
+        } catch (Exception e) {
+            log.error("[Redis Fail-Safe] 강제 킥아웃 수배령 조회 실패 (Fail-Close) - AdminId: {}", adminId, e);
             return true;
         }
     }

--- a/src/main/java/com/dekk/app/admin/presentation/controller/AdminAuthApi.java
+++ b/src/main/java/com/dekk/app/admin/presentation/controller/AdminAuthApi.java
@@ -7,24 +7,26 @@ import com.dekk.global.swagger.ApiErrorExceptions;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
 
-@Tag(name = "관리자 인증 API", description = "관리자 인증 관련 API")
+@Tag(name = "관리자 인증 API", description = "관리자 로그인 및 로그아웃 API")
 public interface AdminAuthApi {
 
-    @Operation(summary = "관리자 로그인", description = "이메일과 비밀번호를 사용하여 관리자 액세스 토큰을 발급받습니다.")
+    @Operation(summary = "관리자 로그인", description = "이메일과 비밀번호를 사용하여 관리자 토큰(Access/Refresh)을 발급받아 쿠키에 저장합니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관리자 로그인 성공")
     @ApiErrorExceptions(AdminErrorCode.class)
-    ResponseEntity<ApiResponse<Void>> login(AdminLoginRequest request, HttpServletResponse response);
+    ResponseEntity<ApiResponse<Void>> login(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "로그인 정보") AdminLoginRequest request,
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) HttpServletResponse response);
 
-    @Operation(
-            summary = "관리자 로그아웃",
-            description = "어드민 토큰을 블랙리스트에 등록하고 쿠키를 만료시킵니다. (토큰이 없거나 이미 만료된 경우 별도 처리 없이 200 OK를 반환합니다.)")
+    @Operation(summary = "관리자 로그아웃", description = "어드민 토큰을 블랙리스트에 등록하고 쿠키를 만료시킵니다.")
     @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관리자 로그아웃 성공")
     @ApiErrorExceptions(AdminErrorCode.class)
     ResponseEntity<ApiResponse<Void>> logout(
-            @Parameter(hidden = true) @CookieValue(value = "admin_access_token", required = false) String accessToken,
-            HttpServletResponse response);
+            @Parameter(hidden = true) String accessToken,
+            @Parameter(hidden = true) Long adminId,
+            @Parameter(hidden = true) HttpServletResponse response);
 }

--- a/src/main/java/com/dekk/app/admin/presentation/controller/AdminAuthController.java
+++ b/src/main/java/com/dekk/app/admin/presentation/controller/AdminAuthController.java
@@ -5,7 +5,10 @@ import com.dekk.app.admin.application.dto.result.AdminLoginResult;
 import com.dekk.app.admin.presentation.request.AdminLoginRequest;
 import com.dekk.app.admin.presentation.response.AdminResultCode;
 import com.dekk.global.response.ApiResponse;
+import com.dekk.global.security.annotation.LoginAdmin;
+import com.dekk.global.security.util.ClientIpExtractor;
 import com.dekk.global.security.util.CookieUtil;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -23,20 +26,29 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminAuthController implements AdminAuthApi {
 
     private static final String ADMIN_TOKEN_COOKIE_NAME = "admin_access_token";
+    private static final String ADMIN_REFRESH_TOKEN_COOKIE_NAME = "admin_refresh_token";
 
     private final AdminAuthService adminAuthService;
     private final CookieUtil cookieUtil;
 
     @Value("${jwt.admin-access-token-validity-in-seconds}")
-    private int cookieMaxAge;
+    private int accessTokenMaxAge;
+
+    @Value("${jwt.admin-refresh-token-validity-in-seconds}")
+    private int refreshTokenMaxAge;
 
     @Override
     @PostMapping("/login")
     public ResponseEntity<ApiResponse<Void>> login(
-            @Valid @RequestBody AdminLoginRequest request, HttpServletResponse response) {
+            @Valid @RequestBody AdminLoginRequest request,
+            HttpServletRequest httpRequest,
+            HttpServletResponse response) {
+        String clientIp = ClientIpExtractor.extract(httpRequest);
 
-        AdminLoginResult result = adminAuthService.login(request.toCommand());
-        cookieUtil.addCookie(response, ADMIN_TOKEN_COOKIE_NAME, result.accessToken(), cookieMaxAge);
+        AdminLoginResult result = adminAuthService.login(request.toCommand(clientIp));
+
+        cookieUtil.addCookie(response, ADMIN_TOKEN_COOKIE_NAME, result.accessToken(), accessTokenMaxAge);
+        cookieUtil.addCookie(response, ADMIN_REFRESH_TOKEN_COOKIE_NAME, result.refreshToken(), refreshTokenMaxAge);
 
         return ResponseEntity.ok(ApiResponse.from(AdminResultCode.ADMIN_LOGIN_SUCCESS));
     }
@@ -45,11 +57,12 @@ public class AdminAuthController implements AdminAuthApi {
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Void>> logout(
             @CookieValue(value = ADMIN_TOKEN_COOKIE_NAME, required = false) String accessToken,
+            @LoginAdmin Long adminId,
             HttpServletResponse response) {
-
-        adminAuthService.logout(accessToken);
+        adminAuthService.logout(accessToken, adminId);
 
         cookieUtil.deleteCookie(response, ADMIN_TOKEN_COOKIE_NAME);
+        cookieUtil.deleteCookie(response, ADMIN_REFRESH_TOKEN_COOKIE_NAME);
 
         return ResponseEntity.ok(ApiResponse.from(AdminResultCode.ADMIN_LOGOUT_SUCCESS));
     }

--- a/src/main/java/com/dekk/app/admin/presentation/controller/AdminCommandApi.java
+++ b/src/main/java/com/dekk/app/admin/presentation/controller/AdminCommandApi.java
@@ -1,0 +1,40 @@
+package com.dekk.app.admin.presentation.controller;
+
+import com.dekk.app.admin.domain.exception.AdminErrorCode;
+import com.dekk.app.admin.presentation.request.AdminInviteRequest;
+import com.dekk.app.admin.presentation.request.AdminSignupRequest;
+import com.dekk.global.response.ApiResponse;
+import com.dekk.global.swagger.ApiErrorExceptions;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "관리자 계정 제어 API", description = "최고 관리자 전용 초대, 가입 승인 및 강제 킥아웃(Kill-Switch) API")
+public interface AdminCommandApi {
+
+    @Operation(summary = "신규 관리자 초대 링크 발송", description = "오직 SUPER_ADMIN 권한을 가진 계정만 호출할 수 있습니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관리자 초대 성공 (SAD20003)")
+    @ApiErrorExceptions(AdminErrorCode.class)
+    ResponseEntity<ApiResponse<Void>> inviteAdmin(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "초대할 관리자 정보")
+                    AdminInviteRequest request,
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) Long inviterId);
+
+    @Operation(summary = "관리자 가입 완료 (초대 수락)", description = "이메일 초대 링크를 통해 받은 토큰과 설정할 비밀번호, 소속을 전송하여 가입을 완료합니다.")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "201", description = "관리자 계정 생성 완료 (SAD20101)")
+    @ApiErrorExceptions(AdminErrorCode.class)
+    ResponseEntity<ApiResponse<Void>> completeSignup(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "가입 완료 정보") AdminSignupRequest request,
+            @Parameter(hidden = true) HttpServletRequest httpRequest);
+
+    @Operation(summary = "관리자 강제 정지 (Kill-Switch)", description = "특정 관리자의 계정을 정지시키고 접속을 즉시 차단합니다. (SUPER_ADMIN 전용)")
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "관리자 정지 성공 (SAD20004)")
+    @ApiErrorExceptions(AdminErrorCode.class)
+    ResponseEntity<ApiResponse<Void>> suspendAdmin(
+            @Parameter(description = "정지시킬 관리자 ID") Long targetAdminId,
+            @Parameter(hidden = true) HttpServletRequest httpRequest,
+            @Parameter(hidden = true) Long superAdminId);
+}

--- a/src/main/java/com/dekk/app/admin/presentation/controller/AdminCommandController.java
+++ b/src/main/java/com/dekk/app/admin/presentation/controller/AdminCommandController.java
@@ -1,0 +1,64 @@
+package com.dekk.app.admin.presentation.controller;
+
+import com.dekk.app.admin.application.AdminCommandService;
+import com.dekk.app.admin.presentation.request.AdminInviteRequest;
+import com.dekk.app.admin.presentation.request.AdminSignupRequest;
+import com.dekk.app.admin.presentation.response.AdminResultCode;
+import com.dekk.global.response.ApiResponse;
+import com.dekk.global.security.annotation.LoginAdmin;
+import com.dekk.global.security.util.ClientIpExtractor;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/adm/v1/admins")
+@RequiredArgsConstructor
+public class AdminCommandController implements AdminCommandApi {
+
+    private final AdminCommandService adminCommandService;
+
+    @Override
+    @PostMapping("/invite")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> inviteAdmin(
+            @Valid @RequestBody AdminInviteRequest request,
+            HttpServletRequest httpRequest,
+            @LoginAdmin Long inviterId) {
+        String clientIp = ClientIpExtractor.extract(httpRequest);
+        adminCommandService.inviteAdmin(inviterId, request.toCommand(), clientIp);
+
+        return ResponseEntity.ok(ApiResponse.from(AdminResultCode.ADMIN_INVITED));
+    }
+
+    @Override
+    @PostMapping("/signup")
+    public ResponseEntity<ApiResponse<Void>> completeSignup(
+            @Valid @RequestBody AdminSignupRequest request, HttpServletRequest httpRequest) {
+        String clientIp = ClientIpExtractor.extract(httpRequest);
+        adminCommandService.completeSignup(request.toCommand(), clientIp);
+
+        return ResponseEntity.status(AdminResultCode.ADMIN_CREATED.status())
+                .body(ApiResponse.from(AdminResultCode.ADMIN_CREATED));
+    }
+
+    @Override
+    @PostMapping("/{targetAdminId}/suspend")
+    @PreAuthorize("hasRole('SUPER_ADMIN')")
+    public ResponseEntity<ApiResponse<Void>> suspendAdmin(
+            @PathVariable("targetAdminId") Long targetAdminId,
+            HttpServletRequest httpRequest,
+            @LoginAdmin Long superAdminId) {
+        String clientIp = ClientIpExtractor.extract(httpRequest);
+        adminCommandService.suspendAdmin(superAdminId, targetAdminId, clientIp);
+
+        return ResponseEntity.ok(ApiResponse.from(AdminResultCode.ADMIN_SUSPENDED));
+    }
+}

--- a/src/main/java/com/dekk/app/admin/presentation/request/AdminInviteRequest.java
+++ b/src/main/java/com/dekk/app/admin/presentation/request/AdminInviteRequest.java
@@ -1,0 +1,23 @@
+package com.dekk.app.admin.presentation.request;
+
+import com.dekk.app.admin.application.dto.command.AdminInviteCommand;
+import com.dekk.app.admin.domain.model.AdminRole;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+@Schema(description = "관리자 초대 요청")
+public record AdminInviteRequest(
+        @Schema(description = "초대할 관리자 이메일", example = "new_admin@dekk.co.kr")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @Schema(description = "부여할 권한 (ADMIN 또는 SUPER_ADMIN)", example = "ADMIN")
+        @NotNull(message = "관리자 권한(Role)은 필수입니다.")
+        AdminRole role) {
+    public AdminInviteCommand toCommand() {
+        return new AdminInviteCommand(email, role);
+    }
+}

--- a/src/main/java/com/dekk/app/admin/presentation/request/AdminLoginRequest.java
+++ b/src/main/java/com/dekk/app/admin/presentation/request/AdminLoginRequest.java
@@ -1,22 +1,27 @@
 package com.dekk.app.admin.presentation.request;
 
 import com.dekk.app.admin.application.dto.command.AdminLoginCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
+@Schema(description = "관리자 로그인 요청")
 public record AdminLoginRequest(
-        @NotBlank(message = "이메일은 필수입니다.") @Email(message = "올바른 이메일 형식이 아닙니다.")
+        @Schema(description = "관리자 이메일", example = "admin@dekk.co.kr")
+        @NotBlank(message = "이메일은 필수입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
 
+        @Schema(description = "비밀번호", example = "DekkAdmin123!")
         @NotBlank(message = "비밀번호는 필수입니다.")
         @Size(min = 8, max = 20, message = "비밀번호는 8자 이상, 20자 이하로 입력해야 합니다.")
         @Pattern(
                 regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,20}$",
                 message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
         String password) {
-    public AdminLoginCommand toCommand() {
-        return new AdminLoginCommand(email, password);
+    public AdminLoginCommand toCommand(String ip) {
+        return new AdminLoginCommand(email, password, ip);
     }
 }

--- a/src/main/java/com/dekk/app/admin/presentation/request/AdminSignupRequest.java
+++ b/src/main/java/com/dekk/app/admin/presentation/request/AdminSignupRequest.java
@@ -1,0 +1,29 @@
+package com.dekk.app.admin.presentation.request;
+
+import com.dekk.app.admin.application.dto.command.AdminSignupCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+@Schema(description = "관리자 가입 완료 요청")
+public record AdminSignupRequest(
+        @Schema(description = "이메일로 전달받은 1회성 초대 토큰") @NotBlank(message = "초대 토큰은 필수입니다.")
+        String token,
+
+        @Schema(description = "설정할 비밀번호 (영문, 숫자, 특수문자 조합 8~20자)", example = "DekkAdmin123!")
+        @NotBlank(message = "비밀번호는 필수입니다.")
+        @Size(min = 8, max = 20, message = "비밀번호는 8자 이상, 20자 이하로 입력해야 합니다.")
+        @Pattern(
+                regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&#])[A-Za-z\\d@$!%*?&#]{8,20}$",
+                message = "비밀번호는 영문, 숫자, 특수문자를 포함해야 합니다.")
+        String password,
+
+        @Schema(description = "관리자 소속(회사/부서명)", example = "DEKK 운영팀")
+        @NotBlank(message = "소속은 필수입니다.")
+        @Size(max = 100, message = "소속은 100자 이내여야 합니다.")
+        String department) {
+    public AdminSignupCommand toCommand() {
+        return new AdminSignupCommand(token, password, department);
+    }
+}

--- a/src/main/java/com/dekk/app/admin/presentation/response/AdminResultCode.java
+++ b/src/main/java/com/dekk/app/admin/presentation/response/AdminResultCode.java
@@ -7,7 +7,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum AdminResultCode implements ResultCode {
     ADMIN_LOGIN_SUCCESS(HttpStatus.OK, "SAD20001", "관리자 로그인에 성공했습니다."),
-    ADMIN_LOGOUT_SUCCESS(HttpStatus.OK, "SAD20002", "관리자 로그아웃에 성공했습니다.");
+    ADMIN_LOGOUT_SUCCESS(HttpStatus.OK, "SAD20002", "관리자 로그아웃에 성공했습니다."),
+    ADMIN_INVITED(HttpStatus.OK, "SAD20003", "관리자 초대 링크가 발송되었습니다."),
+    ADMIN_SUSPENDED(HttpStatus.OK, "SAD20004", "해당 관리자 계정이 강제 정지되었습니다."),
+    ADMIN_CREATED(HttpStatus.CREATED, "SAD20101", "관리자 계정이 성공적으로 생성되었습니다.");
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/java/com/dekk/global/config/AsyncConfig.java
+++ b/src/main/java/com/dekk/global/config/AsyncConfig.java
@@ -5,5 +5,4 @@ import org.springframework.scheduling.annotation.EnableAsync;
 
 @Configuration
 @EnableAsync
-public class AsyncConfig {
-}
+public class AsyncConfig {}

--- a/src/main/java/com/dekk/global/config/AsyncConfig.java
+++ b/src/main/java/com/dekk/global/config/AsyncConfig.java
@@ -1,0 +1,9 @@
+package com.dekk.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+}

--- a/src/main/java/com/dekk/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dekk/global/security/config/SecurityConfig.java
@@ -62,7 +62,8 @@ public class SecurityConfig {
                                 "/w/v1/decks/shared/*/cards",
                                 "/adm/v1/auth/login",
                                 "/adm/v1/auth/logout",
-                                "/w/v1/auth/logout")
+                                "/w/v1/auth/logout",
+                                "/adm/v1/admins/signup")
                         .permitAll()
                         .requestMatchers("/adm/v1/admins/**")
                         .hasRole("SUPER_ADMIN")

--- a/src/main/java/com/dekk/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/dekk/global/security/jwt/JwtTokenProvider.java
@@ -40,6 +40,12 @@ public class JwtTokenProvider {
     private final long accessTokenValidityTime;
     private final long refreshTokenValidityTime;
 
+    @Value("${jwt.admin-access-token-validity-in-seconds}")
+    private long adminAtValidityInSeconds;
+
+    @Value("${jwt.admin-refresh-token-validity-in-seconds}")
+    private long adminRtValidityInSeconds;
+
     public JwtTokenProvider(
             @Value("${jwt.secret}") String secretKey,
             @Value("${jwt.access-token-validity-in-seconds}") long accessTokenValidityInSeconds,
@@ -51,11 +57,17 @@ public class JwtTokenProvider {
     }
 
     public String createAccessToken(Authentication authentication) {
-        return createToken(authentication, accessTokenValidityTime, ACCESS_TOKEN_TYPE);
+        long validTime = (authentication.getPrincipal() instanceof AdminUserDetails)
+                ? adminAtValidityInSeconds * 1000
+                : accessTokenValidityTime;
+        return createToken(authentication, validTime, ACCESS_TOKEN_TYPE);
     }
 
     public String createRefreshToken(Authentication authentication) {
-        return createToken(authentication, refreshTokenValidityTime, REFRESH_TOKEN_TYPE);
+        long validTime = (authentication.getPrincipal() instanceof AdminUserDetails)
+                ? adminRtValidityInSeconds * 1000
+                : refreshTokenValidityTime;
+        return createToken(authentication, validTime, REFRESH_TOKEN_TYPE);
     }
 
     private String createToken(Authentication authentication, long tokenValidTime, String tokenType) {

--- a/src/main/java/com/dekk/global/security/jwt/TokenBlacklistManager.java
+++ b/src/main/java/com/dekk/global/security/jwt/TokenBlacklistManager.java
@@ -1,6 +1,0 @@
-package com.dekk.global.security.jwt;
-
-public interface TokenBlacklistManager {
-
-    boolean isBlacklisted(String token);
-}

--- a/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -17,8 +17,10 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.Arrays;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -51,12 +53,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
-    private final AdminTokenBlackListRepository adminTokenBlackListRepository; // 👈 TokenBlacklistManager 대체
+    private final AdminTokenBlackListRepository adminTokenBlackListRepository;
 
     public JwtAuthenticationFilter(
-            JwtTokenProvider jwtTokenProvider,
-            ObjectMapper objectMapper,
-            AdminTokenBlackListRepository adminTokenBlackListRepository) {
+        JwtTokenProvider jwtTokenProvider,
+        ObjectMapper objectMapper,
+        AdminTokenBlackListRepository adminTokenBlackListRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.objectMapper = objectMapper;
         this.adminTokenBlackListRepository = adminTokenBlackListRepository;
@@ -75,7 +77,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+        throws ServletException, IOException {
 
         String requestUri = request.getRequestURI();
         String jwt = null;
@@ -124,10 +126,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             return Arrays.stream(cookies)
-                    .filter(cookie -> targetCookieName.equals(cookie.getName()))
-                    .map(Cookie::getValue)
-                    .findFirst()
-                    .orElse(null);
+                .filter(cookie -> targetCookieName.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
         }
         return null;
     }

--- a/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -17,10 +17,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.util.Arrays;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -56,9 +54,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final AdminTokenBlackListRepository adminTokenBlackListRepository;
 
     public JwtAuthenticationFilter(
-        JwtTokenProvider jwtTokenProvider,
-        ObjectMapper objectMapper,
-        AdminTokenBlackListRepository adminTokenBlackListRepository) {
+            JwtTokenProvider jwtTokenProvider,
+            ObjectMapper objectMapper,
+            AdminTokenBlackListRepository adminTokenBlackListRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.objectMapper = objectMapper;
         this.adminTokenBlackListRepository = adminTokenBlackListRepository;
@@ -77,7 +75,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-        throws ServletException, IOException {
+            throws ServletException, IOException {
 
         String requestUri = request.getRequestURI();
         String jwt = null;
@@ -126,10 +124,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             return Arrays.stream(cookies)
-                .filter(cookie -> targetCookieName.equals(cookie.getName()))
-                .map(Cookie::getValue)
-                .findFirst()
-                .orElse(null);
+                    .filter(cookie -> targetCookieName.equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
         }
         return null;
     }

--- a/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -17,10 +17,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
 import java.io.IOException;
 import java.util.Arrays;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -56,9 +54,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final AdminTokenBlackListRepository adminTokenBlackListRepository; // 👈 TokenBlacklistManager 대체
 
     public JwtAuthenticationFilter(
-        JwtTokenProvider jwtTokenProvider,
-        ObjectMapper objectMapper,
-        AdminTokenBlackListRepository adminTokenBlackListRepository) {
+            JwtTokenProvider jwtTokenProvider,
+            ObjectMapper objectMapper,
+            AdminTokenBlackListRepository adminTokenBlackListRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.objectMapper = objectMapper;
         this.adminTokenBlackListRepository = adminTokenBlackListRepository;
@@ -77,7 +75,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-        throws ServletException, IOException {
+            throws ServletException, IOException {
 
         String requestUri = request.getRequestURI();
         String jwt = null;
@@ -126,10 +124,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             return Arrays.stream(cookies)
-                .filter(cookie -> targetCookieName.equals(cookie.getName()))
-                .map(Cookie::getValue)
-                .findFirst()
-                .orElse(null);
+                    .filter(cookie -> targetCookieName.equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
         }
         return null;
     }

--- a/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dekk/global/security/jwt/filter/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.dekk.global.security.jwt.filter;
 
 import com.dekk.app.admin.domain.exception.AdminBusinessException;
 import com.dekk.app.admin.domain.exception.AdminErrorCode;
+import com.dekk.app.admin.domain.repository.AdminTokenBlackListRepository;
 import com.dekk.app.admin.security.AdminUserDetails;
 import com.dekk.app.auth.domain.exception.AuthBusinessException;
 import com.dekk.app.auth.domain.exception.AuthErrorCode;
@@ -9,7 +10,6 @@ import com.dekk.global.error.BusinessException;
 import com.dekk.global.error.ErrorCode;
 import com.dekk.global.error.ErrorResponse;
 import com.dekk.global.security.jwt.JwtTokenProvider;
-import com.dekk.global.security.jwt.TokenBlacklistManager;
 import com.dekk.global.security.util.CookieUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
@@ -17,8 +17,11 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 import java.util.Arrays;
+
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,6 +30,7 @@ import org.springframework.util.AntPathMatcher;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
+@Slf4j
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
@@ -49,13 +53,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
-    private final TokenBlacklistManager tokenBlacklistManager;
+    private final AdminTokenBlackListRepository adminTokenBlackListRepository; // 👈 TokenBlacklistManager 대체
 
     public JwtAuthenticationFilter(
-            JwtTokenProvider jwtTokenProvider, ObjectMapper objectMapper, TokenBlacklistManager tokenBlacklistManager) {
+        JwtTokenProvider jwtTokenProvider,
+        ObjectMapper objectMapper,
+        AdminTokenBlackListRepository adminTokenBlackListRepository) {
         this.jwtTokenProvider = jwtTokenProvider;
         this.objectMapper = objectMapper;
-        this.tokenBlacklistManager = tokenBlacklistManager;
+        this.adminTokenBlackListRepository = adminTokenBlackListRepository;
     }
 
     @Override
@@ -71,7 +77,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-            throws ServletException, IOException {
+        throws ServletException, IOException {
 
         String requestUri = request.getRequestURI();
         String jwt = null;
@@ -96,8 +102,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 Authentication authentication = jwtTokenProvider.getAuthentication(jwt);
 
-                if (authentication.getPrincipal() instanceof AdminUserDetails) {
-                    if (tokenBlacklistManager.isBlacklisted(jwt)) {
+                if (authentication.getPrincipal() instanceof AdminUserDetails admin) {
+                    if (adminTokenBlackListRepository.isKickedOut(admin.adminId())) {
+                        log.warn("[Security Alert] Kick-out 대상 접근 차단: {}", admin.adminId());
+                        throw new AdminBusinessException(AdminErrorCode.ACCOUNT_SUSPENDED);
+                    }
+                    if (adminTokenBlackListRepository.isBlacklisted(jwt)) {
                         throw new AdminBusinessException(AdminErrorCode.BLACKLISTED_TOKEN);
                     }
                 }
@@ -116,10 +126,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         Cookie[] cookies = request.getCookies();
         if (cookies != null) {
             return Arrays.stream(cookies)
-                    .filter(cookie -> targetCookieName.equals(cookie.getName()))
-                    .map(Cookie::getValue)
-                    .findFirst()
-                    .orElse(null);
+                .filter(cookie -> targetCookieName.equals(cookie.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
         }
         return null;
     }

--- a/src/main/java/com/dekk/global/security/util/ClientIpExtractor.java
+++ b/src/main/java/com/dekk/global/security/util/ClientIpExtractor.java
@@ -1,0 +1,12 @@
+package com.dekk.global.security.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+public class ClientIpExtractor {
+
+    private ClientIpExtractor() {}
+
+    public static String extract(HttpServletRequest request) {
+        return request.getRemoteAddr();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -67,11 +67,28 @@ spring:
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
 
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${DEV_GMAIL_USERNAME}
+    password: ${DEV_GMAIL_APP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+
 jwt:
   secret: ${DEV_JWT_SECRET_KEY}
   access-token-validity-in-seconds: 31536000
   refresh-token-validity-in-seconds: 31536000
   admin-access-token-validity-in-seconds: 31536000
+  admin-refresh-token-validity-in-seconds: 31536000
 
 app:
   oauth2:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -36,6 +36,23 @@ spring:
     hibernate:
       ddl-auto: validate
     show-sql: false
+
+  mail:
+    host: smtp.gmail.com
+    port: 587
+    username: ${GMAIL_USERNAME}
+    password: ${GMAIL_APP_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+            required: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000
+
   security:
     oauth2:
       client:
@@ -69,6 +86,7 @@ jwt:
   access-token-validity-in-seconds: ${JWT_ACCESS_TOKEN_EXPIRATION}
   refresh-token-validity-in-seconds: ${JWT_REFRESH_TOKEN_EXPIRATION}
   admin-access-token-validity-in-seconds: ${JWT_ADMIN_TOKEN_EXPIRATION}
+  admin-refresh-token-validity-in-seconds: ${JWT_ADMIN_REFRESH_TOKEN_EXPIRATION}
 
 app:
   oauth2:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,7 @@ jwt:
   access-token-validity-in-seconds: 3600
   refresh-token-validity-in-seconds: 1209600
   admin-access-token-validity-in-seconds: 3600
+  admin-refresh-token-validity-in-seconds: 1209600
 
 management:
   endpoints:

--- a/src/main/resources/db/migration/V9__add_department_to_admins.sql
+++ b/src/main/resources/db/migration/V9__add_department_to_admins.sql
@@ -1,0 +1,5 @@
+ALTER TABLE admins
+    ADD COLUMN department VARCHAR(255);
+
+ALTER TABLE admins
+    ADD COLUMN status VARCHAR(50);

--- a/src/main/resources/db/migration/V9__add_department_to_admins.sql
+++ b/src/main/resources/db/migration/V9__add_department_to_admins.sql
@@ -1,5 +1,18 @@
 ALTER TABLE admins
-    ADD COLUMN department VARCHAR(255);
+    ADD COLUMN department VARCHAR(100),
+    ADD COLUMN status VARCHAR(50);
+
+UPDATE admins
+SET department = 'UNKNOWN'
+WHERE department IS NULL;
+
+UPDATE admins
+SET status = 'ACTIVE'
+WHERE status IS NULL;
 
 ALTER TABLE admins
-    ADD COLUMN status VARCHAR(50);
+    ALTER COLUMN department SET NOT NULL,
+    ALTER COLUMN status SET NOT NULL;
+
+ALTER TABLE admins
+    ADD CONSTRAINT chk_admins_status CHECK (status IN ('ACTIVE', 'SUSPENDED'));

--- a/src/test/java/com/dekk/app/admin/application/AdminAuthServiceTest.java
+++ b/src/test/java/com/dekk/app/admin/application/AdminAuthServiceTest.java
@@ -1,14 +1,27 @@
 package com.dekk.app.admin.application;
 
-import com.dekk.app.admin.application.AdminAuthService;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
 import com.dekk.app.admin.application.dto.command.AdminLoginCommand;
 import com.dekk.app.admin.application.dto.result.AdminLoginResult;
 import com.dekk.app.admin.domain.exception.AdminBusinessException;
 import com.dekk.app.admin.domain.exception.AdminErrorCode;
 import com.dekk.app.admin.domain.model.Admin;
 import com.dekk.app.admin.domain.model.AdminRole;
+import com.dekk.app.admin.domain.model.AdminStatus;
+import com.dekk.app.admin.domain.repository.AdminLoginRateLimiter;
+import com.dekk.app.admin.domain.repository.AdminRefreshTokenRepository;
 import com.dekk.app.admin.domain.repository.AdminRepository;
+import com.dekk.app.admin.domain.repository.AdminTokenBlackListRepository;
 import com.dekk.global.security.jwt.JwtTokenProvider;
+
+import java.util.Optional;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,14 +30,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
-
-import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
 class AdminAuthServiceTest {
@@ -41,42 +46,60 @@ class AdminAuthServiceTest {
     @Mock
     private JwtTokenProvider jwtTokenProvider;
 
+    @Mock
+    private AdminTokenBlackListRepository adminTokenBlackListRepository;
+
+    @Mock
+    private AdminRefreshTokenRepository adminRefreshTokenRepository;
+
+    @Mock
+    private AdminLoginRateLimiter adminLoginRateLimiter;
+
     @Test
     @DisplayName("관리자 로그인 성공")
     void login_success() {
         // given
         String email = "admin@dekk.com";
         String password = "password";
-        AdminLoginCommand command = new AdminLoginCommand(email, password);
+        String ip = "127.0.0.1";
+        AdminLoginCommand command = new AdminLoginCommand(email, password, ip);
         Admin admin = mock(Admin.class);
 
+        given(adminLoginRateLimiter.isLocked(ip, email)).willReturn(false);
         given(adminRepository.findByEmail(email)).willReturn(Optional.of(admin));
         given(admin.getPassword()).willReturn("encodedPassword");
         given(passwordEncoder.matches(password, "encodedPassword")).willReturn(true);
+        given(admin.getStatus()).willReturn(AdminStatus.ACTIVE);
         given(admin.getId()).willReturn(1L);
         given(admin.getEmail()).willReturn(email);
         given(admin.getAdminRole()).willReturn(AdminRole.ADMIN);
 
-        given(jwtTokenProvider.createAccessToken(any(Authentication.class))).willReturn("test-token");
+        given(jwtTokenProvider.createAccessToken(any(Authentication.class))).willReturn("test-access-token");
+        given(jwtTokenProvider.createRefreshToken(any(Authentication.class))).willReturn("test-refresh-token");
 
-        // when
         AdminLoginResult result = adminAuthService.login(command);
 
-        // then
-        assertThat(result.accessToken()).isEqualTo("test-token");
+        assertThat(result.accessToken()).isEqualTo("test-access-token");
+        assertThat(result.refreshToken()).isEqualTo("test-refresh-token");
+        verify(adminLoginRateLimiter).resetFailCount(ip, email);
+        verify(adminRefreshTokenRepository).deleteByAdminId(1L);
     }
 
     @Test
     @DisplayName("관리자 로그인 실패 - 존재하지 않는 이메일")
     void login_fail_not_found_email() {
         String email = "notfound@dekk.com";
-        AdminLoginCommand command = new AdminLoginCommand(email, "password");
+        String ip = "127.0.0.1";
+        AdminLoginCommand command = new AdminLoginCommand(email, "password", ip);
 
+        given(adminLoginRateLimiter.isLocked(ip, email)).willReturn(false);
         given(adminRepository.findByEmail(email)).willReturn(Optional.empty());
 
         assertThatThrownBy(() -> adminAuthService.login(command))
             .isInstanceOf(AdminBusinessException.class)
             .hasMessageContaining(AdminErrorCode.ADMIN_NOT_FOUND.message());
+
+        verify(adminLoginRateLimiter).incrementFailCount(ip, email);
     }
 
     @Test
@@ -84,9 +107,11 @@ class AdminAuthServiceTest {
     void login_fail_invalid_password() {
         String email = "admin@dekk.com";
         String password = "wrongpassword";
-        AdminLoginCommand command = new AdminLoginCommand(email, password);
+        String ip = "127.0.0.1";
+        AdminLoginCommand command = new AdminLoginCommand(email, password, ip);
         Admin admin = mock(Admin.class);
 
+        given(adminLoginRateLimiter.isLocked(ip, email)).willReturn(false);
         given(adminRepository.findByEmail(email)).willReturn(Optional.of(admin));
         given(admin.getPassword()).willReturn("encodedPassword");
         given(passwordEncoder.matches(password, "encodedPassword")).willReturn(false);
@@ -94,5 +119,21 @@ class AdminAuthServiceTest {
         assertThatThrownBy(() -> adminAuthService.login(command))
             .isInstanceOf(AdminBusinessException.class)
             .hasMessageContaining(AdminErrorCode.INVALID_PASSWORD.message());
+
+        verify(adminLoginRateLimiter).incrementFailCount(ip, email);
+    }
+
+    @Test
+    @DisplayName("관리자 로그인 실패 - 계정 잠금 상태")
+    void login_fail_account_locked() {
+        String email = "admin@dekk.com";
+        String ip = "127.0.0.1";
+        AdminLoginCommand command = new AdminLoginCommand(email, "password", ip);
+
+        given(adminLoginRateLimiter.isLocked(ip, email)).willReturn(true);
+
+        assertThatThrownBy(() -> adminAuthService.login(command))
+            .isInstanceOf(AdminBusinessException.class)
+            .hasMessageContaining(AdminErrorCode.ACCOUNT_LOCKED.message());
     }
 }

--- a/src/test/java/com/dekk/app/admin/application/AdminCommandServiceTest.java
+++ b/src/test/java/com/dekk/app/admin/application/AdminCommandServiceTest.java
@@ -1,0 +1,194 @@
+package com.dekk.app.admin.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.dekk.app.admin.application.dto.command.AdminSignupCommand;
+import com.dekk.app.admin.domain.exception.AdminBusinessException;
+import com.dekk.app.admin.domain.exception.AdminErrorCode;
+import com.dekk.app.admin.domain.model.Admin;
+import com.dekk.app.admin.domain.model.AdminRole;
+import com.dekk.app.admin.domain.model.AdminStatus;
+import com.dekk.app.admin.domain.repository.AdminRefreshTokenRepository;
+import com.dekk.app.admin.domain.repository.AdminRepository;
+import com.dekk.app.admin.domain.repository.AdminTokenBlackListRepository;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AdminCommandServiceTest {
+
+    private static final String INVITE_KEY = "ADMIN:INVITE:invite-token";
+    private static final String CLIENT_IP = "127.0.0.1";
+
+    @InjectMocks
+    private AdminCommandService adminCommandService;
+
+    @Mock
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Mock
+    private ValueOperations<String, String> valueOperations;
+
+    @Mock
+    private AdminRepository adminRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @Mock
+    private AdminRefreshTokenRepository adminRefreshTokenRepository;
+
+    @Mock
+    private AdminTokenBlackListRepository adminTokenBlackListRepository;
+
+    @Mock
+    private AdminEmailService adminEmailService;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(adminCommandService, "adminAtValidityTime", 3600L);
+    }
+
+    @Test
+    @DisplayName("관리자 가입 완료 시 초대 토큰을 원자적으로 소비한다")
+    void completeSignup_consumesInviteTokenAtomically() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.getAndDelete(INVITE_KEY)).willReturn("new-admin@dekk.com:ADMIN:1");
+        given(adminRepository.existsByEmail("new-admin@dekk.com")).willReturn(false);
+        given(passwordEncoder.encode("DekkAdmin123!")).willReturn("encoded-password");
+        given(adminRepository.saveAndFlush(any(Admin.class))).willAnswer(invocation -> invocation.getArgument(0));
+
+        adminCommandService.completeSignup(
+            new AdminSignupCommand("invite-token", "DekkAdmin123!", "운영팀"), CLIENT_IP);
+
+        ArgumentCaptor<Admin> adminCaptor = ArgumentCaptor.forClass(Admin.class);
+        verify(adminRepository).saveAndFlush(adminCaptor.capture());
+        Admin savedAdmin = adminCaptor.getValue();
+        assertThat(savedAdmin.getEmail()).isEqualTo("new-admin@dekk.com");
+        assertThat(savedAdmin.getAdminRole()).isEqualTo(AdminRole.ADMIN);
+        assertThat(savedAdmin.getStatus()).isEqualTo(AdminStatus.ACTIVE);
+        assertThat(savedAdmin.getDepartment()).isEqualTo("운영팀");
+        verify(valueOperations).getAndDelete(INVITE_KEY);
+        verify(redisTemplate, never()).delete(anyString());
+    }
+
+    @Test
+    @DisplayName("초대 토큰이 없으면 가입 완료에 실패한다")
+    void completeSignup_failsWhenInviteTokenIsMissing() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.getAndDelete(INVITE_KEY)).willReturn(null);
+
+        assertThatThrownBy(() -> adminCommandService.completeSignup(
+            new AdminSignupCommand("invite-token", "DekkAdmin123!", "운영팀"), CLIENT_IP))
+            .isInstanceOf(AdminBusinessException.class)
+            .hasMessageContaining(AdminErrorCode.INVALID_INVITE_TOKEN.message());
+
+        verify(adminRepository, never()).saveAndFlush(any(Admin.class));
+    }
+
+    @Test
+    @DisplayName("이미 등록된 이메일이면 소비된 초대 토큰으로 가입할 수 없다")
+    void completeSignup_failsWhenEmailAlreadyExists() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.getAndDelete(INVITE_KEY)).willReturn("new-admin@dekk.com:ADMIN:1");
+        given(adminRepository.existsByEmail("new-admin@dekk.com")).willReturn(true);
+
+        assertThatThrownBy(() -> adminCommandService.completeSignup(
+            new AdminSignupCommand("invite-token", "DekkAdmin123!", "운영팀"), CLIENT_IP))
+            .isInstanceOf(AdminBusinessException.class)
+            .hasMessageContaining(AdminErrorCode.DUPLICATE_EMAIL.message());
+
+        verify(adminRepository, never()).saveAndFlush(any(Admin.class));
+    }
+
+    @Test
+    @DisplayName("동시 가입 경쟁으로 unique 제약이 충돌하면 중복 이메일 오류로 변환한다")
+    void completeSignup_mapsUniqueConstraintViolationToDuplicateEmail() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.getAndDelete(INVITE_KEY)).willReturn("new-admin@dekk.com:ADMIN:1");
+        given(adminRepository.existsByEmail("new-admin@dekk.com")).willReturn(false);
+        given(passwordEncoder.encode("DekkAdmin123!")).willReturn("encoded-password");
+        given(adminRepository.saveAndFlush(any(Admin.class)))
+            .willThrow(new DataIntegrityViolationException("duplicate email"));
+
+        assertThatThrownBy(() -> adminCommandService.completeSignup(
+            new AdminSignupCommand("invite-token", "DekkAdmin123!", "운영팀"), CLIENT_IP))
+            .isInstanceOf(AdminBusinessException.class)
+            .hasMessageContaining(AdminErrorCode.DUPLICATE_EMAIL.message());
+    }
+
+    @Test
+    @DisplayName("관리자는 자기 자신을 정지할 수 없다")
+    void suspendAdmin_failsWhenTargetIsSelf() {
+        assertThatThrownBy(() -> adminCommandService.suspendAdmin(1L, 1L, CLIENT_IP))
+            .isInstanceOf(AdminBusinessException.class)
+            .hasMessageContaining(AdminErrorCode.CANNOT_SUSPEND_SELF.message());
+
+        verify(adminRepository, never()).findById(any());
+    }
+
+    @Test
+    @DisplayName("마지막 활성 슈퍼 관리자는 정지할 수 없다")
+    void suspendAdmin_failsWhenTargetIsLastActiveSuperAdmin() {
+        Admin target = Admin.create("super@dekk.com", "encoded-password", AdminRole.SUPER_ADMIN, "운영팀");
+        given(adminRepository.findById(2L)).willReturn(Optional.of(target));
+        given(adminRepository.countByAdminRoleAndStatus(AdminRole.SUPER_ADMIN, AdminStatus.ACTIVE)).willReturn(1L);
+
+        assertThatThrownBy(() -> adminCommandService.suspendAdmin(1L, 2L, CLIENT_IP))
+            .isInstanceOf(AdminBusinessException.class)
+            .hasMessageContaining(AdminErrorCode.LAST_SUPER_ADMIN_CANNOT_BE_SUSPENDED.message());
+
+        verify(adminRefreshTokenRepository, never()).deleteByAdminId(any());
+        verify(adminTokenBlackListRepository, never()).saveKickOut(any(), anyLong());
+    }
+
+    @Test
+    @DisplayName("강제 정지 시 kickout 등록에 실패하면 성공 처리하지 않는다")
+    void suspendAdmin_failsWhenKickoutRegistrationFails() {
+        Admin target = Admin.create("admin@dekk.com", "encoded-password", AdminRole.ADMIN, "운영팀");
+        given(adminRepository.findById(2L)).willReturn(Optional.of(target));
+        given(adminTokenBlackListRepository.saveKickOut(2L, 3600L)).willReturn(false);
+
+        assertThatThrownBy(() -> adminCommandService.suspendAdmin(1L, 2L, CLIENT_IP))
+            .isInstanceOf(AdminBusinessException.class)
+            .hasMessageContaining(AdminErrorCode.KICKOUT_REGISTRATION_FAILED.message());
+
+        verify(adminRefreshTokenRepository).deleteByAdminId(2L);
+        assertThat(target.getStatus()).isEqualTo(AdminStatus.SUSPENDED);
+    }
+
+    @Test
+    @DisplayName("관리자 강제 정지에 성공하면 refresh token 삭제와 kickout 등록을 수행한다")
+    void suspendAdmin_success() {
+        Admin target = Admin.create("admin@dekk.com", "encoded-password", AdminRole.ADMIN, "운영팀");
+        given(adminRepository.findById(2L)).willReturn(Optional.of(target));
+        given(adminTokenBlackListRepository.saveKickOut(2L, 3600L)).willReturn(true);
+
+        adminCommandService.suspendAdmin(1L, 2L, CLIENT_IP);
+
+        assertThat(target.getStatus()).isEqualTo(AdminStatus.SUSPENDED);
+        verify(adminRefreshTokenRepository).deleteByAdminId(2L);
+        verify(adminTokenBlackListRepository).saveKickOut(2L, 3600L);
+    }
+}

--- a/src/test/java/com/dekk/app/admin/infrastructure/redis/AdminTokenBlackListRedisRepositoryImplTest.java
+++ b/src/test/java/com/dekk/app/admin/infrastructure/redis/AdminTokenBlackListRedisRepositoryImplTest.java
@@ -32,6 +32,7 @@ class AdminTokenBlackListRedisRepositoryImplTest {
 
     private static final String DUMMY_TOKEN = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.dummy";
     private static final String HASHED_KEY_PREFIX = "BL:ADMIN:";
+    private static final String KICKOUT_KEY_PREFIX = "BL:ADMIN_KICK:";
 
     @Test
     @DisplayName("토큰 저장 시 SHA-256으로 해싱된 키를 사용하여 Redis에 저장한다")
@@ -73,5 +74,34 @@ class AdminTokenBlackListRedisRepositoryImplTest {
     void isBlacklisted_true_when_token_is_blank() {
         assertThat(repository.isBlacklisted(null)).isTrue();
         assertThat(repository.isBlacklisted("   ")).isTrue();
+    }
+
+    @Test
+    @DisplayName("강제 킥아웃 등록에 성공하면 true를 반환한다")
+    void saveKickOut_success() {
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        boolean result = repository.saveKickOut(1L, 3600L);
+
+        assertThat(result).isTrue();
+        verify(valueOperations).set(
+                eq(KICKOUT_KEY_PREFIX + 1L), eq("kicked_out"), eq(3600L), eq(TimeUnit.SECONDS));
+    }
+
+    @Test
+    @DisplayName("강제 킥아웃 등록 중 Redis 장애가 발생하면 false를 반환한다")
+    void saveKickOut_false_when_redis_down() {
+        given(redisTemplate.opsForValue()).willThrow(new RedisConnectionFailureException("Redis Down"));
+
+        boolean result = repository.saveKickOut(1L, 3600L);
+
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("강제 킥아웃 등록 입력값이 유효하지 않으면 false를 반환한다")
+    void saveKickOut_false_when_invalid_input() {
+        assertThat(repository.saveKickOut(null, 3600L)).isFalse();
+        assertThat(repository.saveKickOut(1L, 0L)).isFalse();
     }
 }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -60,6 +60,7 @@ jwt:
   access-token-validity-in-seconds: 3600
   refresh-token-validity-in-seconds: 604800
   admin-access-token-validity-in-seconds: 3600
+  admin-refresh-token-validity-in-seconds: 1209600
 
 storage:
   region: ap-northeast-2

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,7 +35,6 @@ spring:
             token-uri: https://oauth2.googleapis.com/token
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
 
-  # 👇 CI 빌드 에러를 막기 위해 추가된 가짜 메일 설정입니다!
   mail:
     host: localhost
     port: 587

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -35,6 +35,13 @@ spring:
             token-uri: https://oauth2.googleapis.com/token
             user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
 
+  # 👇 CI 빌드 에러를 막기 위해 추가된 가짜 메일 설정입니다!
+  mail:
+    host: localhost
+    port: 587
+    username: test-admin@dekk.com
+    password: dummy-password
+
 cloud:
   aws:
     credentials:


### PR DESCRIPTION
## #️⃣연관된 이슈

> # [DK-480](https://potenup-final.atlassian.net/browse/DK-480)

## 📝작업 내용

이번 PR에서는 DEKK 백오피스 환경을 위한 **Zero-Trust 기반의 관리자 인증/인가 체계 및 초대 시스템**을 구축했습니다. 일반 유저(B2C)와 관리자(B2B)의 보안 도메인을 완전히 분리하고, 엔터프라이즈급 보안 규칙을 적용했습니다.

**1. 관리자 초대 및 가입 시스템 구축 (Google SMTP)**
* `SUPER_ADMIN` 권한을 가진 관리자만 신규 관리자를 초대할 수 있는 API 구현 (`/adm/v1/admins/invite`)
* `Spring Boot Mail`을 활용한 Google SMTP 연동 (`@Async`를 통한 비동기 이메일 발송)
* Redis를 활용하여 24시간 유효한 1회성 가입 토큰(Invite Token) 발급 및 검증
* 초대받은 관리자의 비밀번호 자가 설정 및 소속(Department) 입력 로직 구현 (`/adm/v1/admins/signup`)

**2. 관리자 인증 및 세션 제어**
* 관리자 전용 JWT 토큰(HttpOnly Cookie) 발급 및 검증 로직 구현 (`AdminUserDetails` 분리)
* 단일 세션 유지: 로그인 성공 시 동일 계정으로 발급된 기존 Refresh Token을 즉시 파기하여 중복 로그인을 방지하고 한 기기에서만 접속을 유지하도록 제어
* **Brute-Force 방어망:** Redis를 활용해 연속 5회 로그인 실패 시 30분간 계정 잠금 처리 (Rate Limiting)

**3. Zero-Trust 기반 킬 스위치 (Kill-Switch)**
* 특정 관리자를 즉시 서비스에서 차단하는 강제 정지 API 구현 (`/adm/v1/admins/{id}/suspend`)
* Redis 캐시를 활용한 `KICKOUT` 블랙리스트 설계
* `JwtAuthenticationFilter`에서 어드민 요청 시 강제 정지 여부를 실시간 검사하여 `403 Forbidden` (`EAD40303`) 반환 

**4. 인프라 및 DB 안정성 확보**
* Redis 장애 시 서비스 전체가 중단되지 않도록 `Fail-Open/Fail-Close` 정책이 적용된 예외 처리(`try-catch`) 로직 구현
* `admins` 테이블 스키마 업데이트 (Flyway V9 - `department`, `status` 컬럼 추가)

### 스크린샷 (선택)

<details>
<summary><b>1. 초대장 발송 및 메일 수신 완료</b></summary>
<br>

* **신규 관리자 초대 토큰 발송 API:**
<img width="727" height="735" alt="신규관리자 초대 토큰 발송" src="https://github.com/user-attachments/assets/803eb0d2-153e-4d99-bf7e-f188529b1830" />

* **실제 수신된 Google 이메일 초대장:**
<img width="1512" height="982" alt="구글 이메일 초대 성공" src="https://github.com/user-attachments/assets/23342153-5e5d-40be-93bd-266aa7a112e7" />


</details>

<details>
<summary><b>2. 가입 완료 및 로그인 성공</b></summary>
<br>

* **초대받은 관리자 가입 완료:**
<img width="756" height="744" alt="초대받은 관리자 가입완료" src="https://github.com/user-attachments/assets/b4fb4249-a2fb-46aa-a7cc-a6af43c3c13e" />

* **신규 관리자 로그인 성공 (쿠키 발급):**
<img width="1508" height="947" alt="신규관리자 로그인 성공" src="https://github.com/user-attachments/assets/eb9bee27-a8c8-4c75-93ac-1ec1b9bf96d8" />


</details>

<details>
<summary><b>3. 보안 방어막 (Brute-Force & Kill-Switch) 작동 테스트</b></summary>
<br>

* **무차별 대입(Brute Force) 5회 실패 시 30분 잠금:**
<img width="1508" height="947" alt="무차별 대입(Brute Force) 로그인 잠금 테스트" src="https://github.com/user-attachments/assets/a8666e95-475e-4a02-a8d2-10a47a8bebec" />


* **최고 관리자의 강제 정지(Kill-Switch) 실행:**
<img width="1508" height="947" alt="관리자 강제 정지 성공" src="https://github.com/user-attachments/assets/a0834d35-fe97-48ac-896c-83f89168a7da" />

* **정지된 계정의 옛날 토큰으로 접근 시 403 차단 (킬 스위치 발동):**
<img width="1350" height="598" alt="정지한 어드민 토큰으로 어드민 전용 API호출" src="https://github.com/user-attachments/assets/6c7fb9f7-40ae-4c54-bc36-3d1322149fb1" />


</details>

## 💬리뷰 요구사항(선택)

* **보안 및 예외 처리:** `AdminTokenBlackListRedisRepositoryImpl` 등 Redis 인프라 단에서 장애 발생 시 시스템이 멈추지 않도록 설계한 Fail-Safe 로직을 중점적으로 살펴봐 주시면 감사하겠습니다.
* **환경 변수 안내:** 운영 및 개발 서버 배포 시 Google SMTP 연동을 위해 환경 변수 `GMAIL_USERNAME`과 `GMAIL_APP_PASSWORD` 주입이 필요합니다.(환경 변수 주입 완료)
* `JwtAuthenticationFilter`에서 관리자(Admin)와 일반 유저의 토큰 검증 분기 처리가 의도대로 잘 격리되었는지 리뷰 부탁드립니다!

[DK-480]: https://potenup-final.atlassian.net/browse/DK-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ