### PR TITLE
[REFACTOR] active_logs 중복 쿼리 제거 및 SwipedCards VO 도입

### DIFF
--- a/src/main/java/com/dekk/app/activelog/application/ActiveLogQueryService.java
+++ b/src/main/java/com/dekk/app/activelog/application/ActiveLogQueryService.java
@@ -1,10 +1,13 @@
 package com.dekk.app.activelog.application;
 
 import com.dekk.app.activelog.domain.model.SwipeType;
+import com.dekk.app.activelog.domain.model.SwipedCards;
 import com.dekk.app.activelog.domain.repository.ActiveLogRepository;
-import java.util.HashSet;
+import com.dekk.app.activelog.domain.repository.CardSwipeProjection;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,14 +19,16 @@ public class ActiveLogQueryService {
 
     private final ActiveLogRepository activeLogRepository;
 
-    public Set<Long> getAllSwipedCardIds(Long userId) {
-        List<SwipeType> targetTypes = List.of(SwipeType.LIKE, SwipeType.DISLIKE);
-        List<Long> cardIds = activeLogRepository.findCardIdsByUserIdAndSwipeTypes(userId, targetTypes);
+    public SwipedCards getSwipedCards(Long userId) {
+        Map<SwipeType, Set<Long>> grouped =
+                activeLogRepository
+                        .findCardIdAndSwipeTypeByUserId(userId, List.of(SwipeType.LIKE, SwipeType.DISLIKE))
+                        .stream()
+                        .collect(Collectors.groupingBy(
+                                CardSwipeProjection::getSwipeType,
+                                Collectors.mapping(CardSwipeProjection::getCardId, Collectors.toSet())));
 
-        return new HashSet<>(cardIds);
-    }
-
-    public List<Long> getSwipedCardIds(Long userId, SwipeType swipeType) {
-        return activeLogRepository.findCardIdsByUserIdAndSwipeTypes(userId, List.of(swipeType));
+        return new SwipedCards(
+                grouped.getOrDefault(SwipeType.LIKE, Set.of()), grouped.getOrDefault(SwipeType.DISLIKE, Set.of()));
     }
 }

--- a/src/main/java/com/dekk/app/activelog/domain/model/SwipedCards.java
+++ b/src/main/java/com/dekk/app/activelog/domain/model/SwipedCards.java
@@ -1,0 +1,28 @@
+package com.dekk.app.activelog.domain.model;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public record SwipedCards(Set<Long> likedIds, Set<Long> dislikedIds) {
+
+    public SwipedCards {
+        likedIds = Set.copyOf(likedIds);
+        dislikedIds = Set.copyOf(dislikedIds);
+    }
+
+    public static SwipedCards empty() {
+        return new SwipedCards(Set.of(), Set.of());
+    }
+
+    public Set<Long> allSwipedIds() {
+        if (likedIds.isEmpty()) return dislikedIds;
+        if (dislikedIds.isEmpty()) return likedIds;
+        Set<Long> all = new HashSet<>(likedIds);
+        all.addAll(dislikedIds);
+        return all;
+    }
+
+    public boolean isAlreadySwiped(Long cardId) {
+        return likedIds.contains(cardId) || dislikedIds.contains(cardId);
+    }
+}

--- a/src/main/java/com/dekk/app/activelog/domain/repository/ActiveLogRepository.java
+++ b/src/main/java/com/dekk/app/activelog/domain/repository/ActiveLogRepository.java
@@ -3,16 +3,11 @@ package com.dekk.app.activelog.domain.repository;
 import com.dekk.app.activelog.domain.model.ActiveLog;
 import com.dekk.app.activelog.domain.model.SwipeType;
 import java.util.List;
-import java.util.Optional;
 
 public interface ActiveLogRepository {
     ActiveLog save(ActiveLog activeLog);
 
     boolean existsByUserIdAndCardId(Long userId, Long cardId);
 
-    Optional<ActiveLog> findByUserIdAndCardId(Long userId, Long cardId);
-
-    void delete(ActiveLog activeLog);
-
-    List<Long> findCardIdsByUserIdAndSwipeTypes(Long userId, List<SwipeType> swipeTypes);
+    List<CardSwipeProjection> findCardIdAndSwipeTypeByUserId(Long userId, List<SwipeType> swipeTypes);
 }

--- a/src/main/java/com/dekk/app/activelog/domain/repository/CardSwipeProjection.java
+++ b/src/main/java/com/dekk/app/activelog/domain/repository/CardSwipeProjection.java
@@ -1,0 +1,9 @@
+package com.dekk.app.activelog.domain.repository;
+
+import com.dekk.app.activelog.domain.model.SwipeType;
+
+public interface CardSwipeProjection {
+    Long getCardId();
+
+    SwipeType getSwipeType();
+}

--- a/src/main/java/com/dekk/app/activelog/infrastructure/ActiveLogRepositoryImpl.java
+++ b/src/main/java/com/dekk/app/activelog/infrastructure/ActiveLogRepositoryImpl.java
@@ -3,9 +3,9 @@ package com.dekk.app.activelog.infrastructure;
 import com.dekk.app.activelog.domain.model.ActiveLog;
 import com.dekk.app.activelog.domain.model.SwipeType;
 import com.dekk.app.activelog.domain.repository.ActiveLogRepository;
+import com.dekk.app.activelog.domain.repository.CardSwipeProjection;
 import com.dekk.app.activelog.infrastructure.jpa.ActiveLogJpaRepository;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -26,17 +26,7 @@ public class ActiveLogRepositoryImpl implements ActiveLogRepository {
     }
 
     @Override
-    public Optional<ActiveLog> findByUserIdAndCardId(Long userId, Long cardId) {
-        return jpaRepository.findByUserIdAndCardId(userId, cardId);
-    }
-
-    @Override
-    public void delete(ActiveLog activeLog) {
-        jpaRepository.delete(activeLog);
-    }
-
-    @Override
-    public List<Long> findCardIdsByUserIdAndSwipeTypes(Long userId, List<SwipeType> swipeTypes) {
-        return jpaRepository.findCardIdsByUserIdAndSwipeTypes(userId, swipeTypes);
+    public List<CardSwipeProjection> findCardIdAndSwipeTypeByUserId(Long userId, List<SwipeType> swipeTypes) {
+        return jpaRepository.findCardIdAndSwipeTypeByUserId(userId, swipeTypes);
     }
 }

--- a/src/main/java/com/dekk/app/activelog/infrastructure/jpa/ActiveLogJpaRepository.java
+++ b/src/main/java/com/dekk/app/activelog/infrastructure/jpa/ActiveLogJpaRepository.java
@@ -2,8 +2,8 @@ package com.dekk.app.activelog.infrastructure.jpa;
 
 import com.dekk.app.activelog.domain.model.ActiveLog;
 import com.dekk.app.activelog.domain.model.SwipeType;
+import com.dekk.app.activelog.domain.repository.CardSwipeProjection;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,9 +11,12 @@ import org.springframework.data.repository.query.Param;
 public interface ActiveLogJpaRepository extends JpaRepository<ActiveLog, Long> {
     boolean existsByUserIdAndCardId(Long userId, Long cardId);
 
-    Optional<ActiveLog> findByUserIdAndCardId(Long userId, Long cardId);
-
-    @Query("SELECT a.cardId FROM ActiveLog a WHERE a.userId = :userId AND a.swipeType IN :swipeTypes")
-    List<Long> findCardIdsByUserIdAndSwipeTypes(
+    @Query("""
+            SELECT a.cardId AS cardId, a.swipeType AS swipeType
+            FROM ActiveLog a
+            WHERE a.userId = :userId AND a.swipeType
+                        IN :swipeTypes
+            """)
+    List<CardSwipeProjection> findCardIdAndSwipeTypeByUserId(
             @Param("userId") Long userId, @Param("swipeTypes") List<SwipeType> swipeTypes);
 }

--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
@@ -1,7 +1,7 @@
 package com.dekk.app.card.recommend.application;
 
 import com.dekk.app.activelog.application.ActiveLogQueryService;
-import com.dekk.app.activelog.domain.model.SwipeType;
+import com.dekk.app.activelog.domain.model.SwipedCards;
 import com.dekk.app.card.application.CardCategoryQueryService;
 import com.dekk.app.card.application.CardQueryService;
 import com.dekk.app.card.application.dto.query.RecommendCandidateQuery;
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
@@ -77,7 +78,8 @@ public class RecommendQueryService {
             log.warn("[Recommend] 깊은 스크롤 감지 userId={} page={} - 컨텐츠 다양성 부족 가능성", userId, pageable.getPageNumber());
         }
 
-        Set<Long> swipedIds = activeLogQueryService.getAllSwipedCardIds(userId);
+        SwipedCards swiped = activeLogQueryService.getSwipedCards(userId);
+        Set<Long> swipedIds = swiped.allSwipedIds();
         log.debug(
                 "[Recommend] userId={} swipedCount={} totalNeeded={} recommendTarget={}",
                 userId,
@@ -85,7 +87,7 @@ public class RecommendQueryService {
                 totalNeeded,
                 recommendCount);
 
-        List<MemberCardResult> rankedCandidates = rankCandidates(userId, swipedIds);
+        List<MemberCardResult> rankedCandidates = rankCandidates(userId, swiped);
 
         if (rankedCandidates.size() < recommendCount) {
             log.warn(
@@ -145,10 +147,10 @@ public class RecommendQueryService {
 
     private List<RecommendCardResult> mergeRecommendResults(
             List<MemberCardResult> recommendCards, List<MemberCardResult> normalCards) {
-        List<RecommendCardResult> results = new ArrayList<>(recommendCards.size() + normalCards.size());
-        recommendCards.forEach(c -> results.add(RecommendCardResult.recommended(c)));
-        normalCards.forEach(c -> results.add(RecommendCardResult.normal(c)));
-        return results;
+        return Stream.concat(
+                        recommendCards.stream().map(RecommendCardResult::recommended),
+                        normalCards.stream().map(RecommendCardResult::normal))
+                .toList();
     }
 
     private Slice<RecommendCardResult> toSlice(
@@ -160,16 +162,16 @@ public class RecommendQueryService {
         return new SliceImpl<>(content, pageable, hasNext);
     }
 
-    private List<MemberCardResult> rankCandidates(Long userId, Set<Long> swipedIds) {
+    private List<MemberCardResult> rankCandidates(Long userId, SwipedCards swiped) {
         UserInfoResult userInfo = userQueryService.getMyInfo(userId);
         List<MemberCardResult> candidates = fetchCandidates(userInfo).stream()
-                .filter(card -> !swipedIds.contains(card.cardId()))
+                .filter(card -> !swiped.isAlreadySwiped(card.cardId()))
                 .toList();
 
         if (candidates.size() >= LARGE_CANDIDATE_THRESHOLD) {
             log.warn("[Recommend] 대용량 후보군 스코어링 userId={} candidateCount={} - 인메모리 부하 위험", userId, candidates.size());
         }
-        Map<Long, Double> preferences = buildCategoryPreferences(userId);
+        Map<Long, Double> preferences = buildCategoryPreferences(swiped.likedIds());
 
         if (preferences.isEmpty()) {
             log.info("[Recommend] cold-start userId={} (카테고리 선호 없음, 체형 기반으로만 추천)", userId);
@@ -187,8 +189,8 @@ public class RecommendQueryService {
                 userInfo.height(), userInfo.weight(), candidates, cardCategoryMap, preferences);
     }
 
-    private Map<Long, Double> buildCategoryPreferences(Long userId) {
-        List<Long> likedCategoryIds = getLikedCategoryIds(userId);
+    private Map<Long, Double> buildCategoryPreferences(Set<Long> likedIds) {
+        List<Long> likedCategoryIds = getLikedCategoryIds(likedIds);
         return recommendScoringService.calculateCategoryPreferenceRatios(likedCategoryIds);
     }
 
@@ -201,9 +203,11 @@ public class RecommendQueryService {
                 .toList();
     }
 
-    private List<Long> getLikedCategoryIds(Long userId) {
-        List<Long> likedCardIds = activeLogQueryService.getSwipedCardIds(userId, SwipeType.LIKE);
-        return cardCategoryQueryService.getCardCategoryMap(likedCardIds).values().stream()
+    private List<Long> getLikedCategoryIds(Set<Long> likedIds) {
+        if (likedIds.isEmpty()) {
+            return List.of();
+        }
+        return cardCategoryQueryService.getCardCategoryMap(new ArrayList<>(likedIds)).values().stream()
                 .flatMap(List::stream)
                 .toList();
     }

--- a/src/test/java/com/dekk/app/activelog/application/ActiveLogQueryServiceTest.java
+++ b/src/test/java/com/dekk/app/activelog/application/ActiveLogQueryServiceTest.java
@@ -4,14 +4,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.dekk.app.activelog.application.ActiveLogQueryService;
 import com.dekk.app.activelog.domain.model.SwipeType;
+import com.dekk.app.activelog.domain.model.SwipedCards;
 import com.dekk.app.activelog.domain.repository.ActiveLogRepository;
+import com.dekk.app.activelog.domain.repository.CardSwipeProjection;
 
 import java.util.List;
-import java.util.Set;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -30,38 +31,41 @@ class ActiveLogQueryServiceTest {
     private ActiveLogQueryService activeLogQueryService;
 
     @Test
-    @DisplayName("전체 스와이프 목록 조회 시 중복이 제거된 Set 구조로 반환되어야 한다")
-    void getAllSwipedCardIds_ReturnSet() {
-
+    @DisplayName("1회 조회 후 SwipeType별로 분리된 SwipedCards를 반환한다")
+    void getSwipedCards_separatesBySwipeType() {
         Long userId = 1L;
-        List<Long> mockList = List.of(10L, 20L, 10L);
-        given(activeLogRepository.findCardIdsByUserIdAndSwipeTypes(eq(userId), anyList()))
-            .willReturn(mockList);
+        CardSwipeProjection p1 = projection(10L, SwipeType.LIKE);
+        CardSwipeProjection p2 = projection(20L, SwipeType.LIKE);
+        CardSwipeProjection p3 = projection(30L, SwipeType.DISLIKE);
+        given(activeLogRepository.findCardIdAndSwipeTypeByUserId(eq(userId), anyList()))
+            .willReturn(List.of(p1, p2, p3));
 
-        Set<Long> result = activeLogQueryService.getAllSwipedCardIds(userId);
+        SwipedCards result = activeLogQueryService.getSwipedCards(userId);
 
-        assertThat(result).isInstanceOf(Set.class);
-        assertThat(result).hasSize(2);
-        assertThat(result).containsExactlyInAnyOrder(10L, 20L);
-        verify(activeLogRepository).findCardIdsByUserIdAndSwipeTypes(eq(userId), anyList());
+        assertThat(result.likedIds()).containsExactlyInAnyOrder(10L, 20L);
+        assertThat(result.dislikedIds()).containsExactlyInAnyOrder(30L);
+        assertThat(result.allSwipedIds()).containsExactlyInAnyOrder(10L, 20L, 30L);
+        verify(activeLogRepository).findCardIdAndSwipeTypeByUserId(eq(userId), anyList());
     }
 
     @Test
-    @DisplayName("특정 타입 조회 시 내부적으로 IN 절 메서드를 호출하여 리스트를 반환한다")
-    void getSwipedCardIds_ReturnList() {
-
+    @DisplayName("스와이프 이력이 없으면 빈 SwipedCards를 반환한다")
+    void getSwipedCards_returnsEmpty_whenNoHistory() {
         Long userId = 1L;
-        SwipeType type = SwipeType.LIKE;
-        List<Long> mockList = List.of(10L, 20L);
+        given(activeLogRepository.findCardIdAndSwipeTypeByUserId(eq(userId), anyList()))
+            .willReturn(List.of());
 
-        given(activeLogRepository.findCardIdsByUserIdAndSwipeTypes(userId, List.of(type)))
-            .willReturn(mockList);
+        SwipedCards result = activeLogQueryService.getSwipedCards(userId);
 
-        List<Long> result = activeLogQueryService.getSwipedCardIds(userId, type);
+        assertThat(result.likedIds()).isEmpty();
+        assertThat(result.dislikedIds()).isEmpty();
+        assertThat(result.allSwipedIds()).isEmpty();
+    }
 
-        assertThat(result).hasSize(2);
-        assertThat(result).isEqualTo(mockList);
-
-        verify(activeLogRepository).findCardIdsByUserIdAndSwipeTypes(userId, List.of(type));
+    private CardSwipeProjection projection(Long cardId, SwipeType swipeType) {
+        CardSwipeProjection p = mock(CardSwipeProjection.class);
+        given(p.getCardId()).willReturn(cardId);
+        given(p.getSwipeType()).willReturn(swipeType);
+        return p;
     }
 }

--- a/src/test/java/com/dekk/app/activelog/infrastructure/jpa/ActiveLogJpaRepositoryTest.java
+++ b/src/test/java/com/dekk/app/activelog/infrastructure/jpa/ActiveLogJpaRepositoryTest.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.dekk.app.activelog.domain.model.ActiveLog;
 import com.dekk.app.activelog.domain.model.SwipeType;
-
+import com.dekk.app.activelog.domain.repository.CardSwipeProjection;
 import com.dekk.app.activelog.infrastructure.jpa.ActiveLogJpaRepository;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,35 +25,39 @@ class ActiveLogJpaRepositoryTest {
     private ActiveLogJpaRepository activeLogJpaRepository;
 
     @Test
-    @DisplayName("특정 유저의 여러 SwipeType(LIKE, DISLIKE)에 해당하는 카드 ID 목록을 한 번에 조회한다")
-    void findCardIdsByUserIdAndSwipeTypes_Success() {
-
+    @DisplayName("LIKE/DISLIKE 조회 시 cardId와 swipeType 쌍이 함께 반환된다")
+    void findCardIdAndSwipeTypeByUserId_returnsAllTypes() {
         Long userId = 1L;
         activeLogJpaRepository.save(ActiveLog.create(userId, 101L, SwipeType.LIKE));
         activeLogJpaRepository.save(ActiveLog.create(userId, 102L, SwipeType.DISLIKE));
         activeLogJpaRepository.save(ActiveLog.create(userId, 103L, SwipeType.LIKE));
         activeLogJpaRepository.save(ActiveLog.create(2L, 104L, SwipeType.LIKE));
 
-        List<SwipeType> targetTypes = List.of(SwipeType.LIKE, SwipeType.DISLIKE);
+        List<CardSwipeProjection> rows = activeLogJpaRepository.findCardIdAndSwipeTypeByUserId(
+                userId, List.of(SwipeType.LIKE, SwipeType.DISLIKE));
 
-        List<Long> result = activeLogJpaRepository.findCardIdsByUserIdAndSwipeTypes(userId, targetTypes);
-
-        assertThat(result).hasSize(3);
-        assertThat(result).containsExactlyInAnyOrder(101L, 102L, 103L);
-        assertThat(result).doesNotContain(104L);
+        assertThat(rows).hasSize(3);
+        Map<SwipeType, List<Long>> grouped = rows.stream()
+                .collect(Collectors.groupingBy(
+                        CardSwipeProjection::getSwipeType,
+                        Collectors.mapping(CardSwipeProjection::getCardId, Collectors.toList())));
+        assertThat(grouped.get(SwipeType.LIKE)).containsExactlyInAnyOrder(101L, 103L);
+        assertThat(grouped.get(SwipeType.DISLIKE)).containsExactlyInAnyOrder(102L);
+        assertThat(rows.stream().map(CardSwipeProjection::getCardId).toList()).doesNotContain(104L);
     }
 
     @Test
-    @DisplayName("단일 타입 조회 시 IN 절을 통해 요청한 타입의 카드 ID만 정확히 반환한다")
-    void findCardIdsByUserIdAndSingleSwipeType_Success() {
-
+    @DisplayName("LIKE 단일 타입만 요청하면 LIKE 카드 ID만 반환된다")
+    void findCardIdAndSwipeTypeByUserId_filtersBySingleType() {
         Long userId = 1L;
         activeLogJpaRepository.save(ActiveLog.create(userId, 101L, SwipeType.LIKE));
         activeLogJpaRepository.save(ActiveLog.create(userId, 102L, SwipeType.DISLIKE));
 
-        List<Long> result = activeLogJpaRepository.findCardIdsByUserIdAndSwipeTypes(userId, List.of(SwipeType.LIKE));
+        List<CardSwipeProjection> rows = activeLogJpaRepository.findCardIdAndSwipeTypeByUserId(
+                userId, List.of(SwipeType.LIKE));
 
-        assertThat(result).hasSize(1);
-        assertThat(result).containsOnly(101L);
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0).getCardId()).isEqualTo(101L);
+        assertThat(rows.getFirst().getSwipeType()).isEqualTo(SwipeType.LIKE);
     }
 }

--- a/src/test/java/com/dekk/app/card/recommend/application/RecommendQueryServiceTest.java
+++ b/src/test/java/com/dekk/app/card/recommend/application/RecommendQueryServiceTest.java
@@ -7,7 +7,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 import com.dekk.app.activelog.application.ActiveLogQueryService;
-import com.dekk.app.activelog.domain.model.SwipeType;
+import com.dekk.app.activelog.domain.model.SwipedCards;
 import com.dekk.app.card.application.CardCategoryQueryService;
 import com.dekk.app.card.application.CardQueryService;
 import com.dekk.app.card.application.dto.result.GuestCardResult;
@@ -44,16 +44,11 @@ class RecommendQueryServiceTest {
     private static final Long USER_ID = 1L;
     private static final int SIZE = 10;
 
-    @Mock
-    private CardQueryService cardQueryService;
-    @Mock
-    private UserQueryService userQueryService;
-    @Mock
-    private ActiveLogQueryService activeLogQueryService;
-    @Mock
-    private CardCategoryQueryService cardCategoryQueryService;
-    @Mock
-    private RecommendScoringService recommendScoringService;
+    @Mock private CardQueryService cardQueryService;
+    @Mock private UserQueryService userQueryService;
+    @Mock private ActiveLogQueryService activeLogQueryService;
+    @Mock private CardCategoryQueryService cardCategoryQueryService;
+    @Mock private RecommendScoringService recommendScoringService;
 
     @InjectMocks
     private RecommendQueryService recommendQueryService;
@@ -65,7 +60,7 @@ class RecommendQueryServiceTest {
         @BeforeEach
         void setUp() {
             given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
-            given(activeLogQueryService.getSwipedCardIds(USER_ID, SwipeType.LIKE)).willReturn(List.of());
+            given(activeLogQueryService.getSwipedCards(USER_ID)).willReturn(SwipedCards.empty());
             given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
             given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
             given(recommendScoringService.rank(any(), any(), any(), any(), any()))
@@ -82,8 +77,8 @@ class RecommendQueryServiceTest {
 
             given(cardQueryService.getRecommendCandidates(any()))
                 .willReturn(List.of(card10, card20, card30));
-            given(activeLogQueryService.getAllSwipedCardIds(USER_ID))
-                .willReturn(Set.of(10L, 20L));
+            given(activeLogQueryService.getSwipedCards(USER_ID))
+                .willReturn(new SwipedCards(Set.of(10L, 20L), Set.of()));
 
             List<RecommendCardResult> result =
                 recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
@@ -101,8 +96,6 @@ class RecommendQueryServiceTest {
 
             given(cardQueryService.getRecommendCandidates(any()))
                 .willReturn(List.of(card1, card2));
-            given(activeLogQueryService.getAllSwipedCardIds(USER_ID))
-                .willReturn(Set.of());
 
             List<RecommendCardResult> result =
                 recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
@@ -118,8 +111,8 @@ class RecommendQueryServiceTest {
 
             given(cardQueryService.getRecommendCandidates(any()))
                 .willReturn(List.of(card1, card2));
-            given(activeLogQueryService.getAllSwipedCardIds(USER_ID))
-                .willReturn(Set.of(1L, 2L));
+            given(activeLogQueryService.getSwipedCards(USER_ID))
+                .willReturn(new SwipedCards(Set.of(1L, 2L), Set.of()));
 
             List<RecommendCardResult> result =
                 recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
@@ -135,8 +128,7 @@ class RecommendQueryServiceTest {
         @BeforeEach
         void setUp() {
             given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
-            given(activeLogQueryService.getAllSwipedCardIds(USER_ID)).willReturn(Set.of());
-            given(activeLogQueryService.getSwipedCardIds(USER_ID, SwipeType.LIKE)).willReturn(List.of());
+            given(activeLogQueryService.getSwipedCards(USER_ID)).willReturn(SwipedCards.empty());
             given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
             given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
         }
@@ -161,8 +153,6 @@ class RecommendQueryServiceTest {
         @Test
         @DisplayName("추천 후보가 부족하면 일반 카드로 나머지를 채운다")
         void shouldFillWithNormalCards_whenRecommendInsufficient() {
-            // 추천 후보 3개뿐 → size=10 기준 추천 7개가 필요하지만 3개만 가능
-            // → 추천 3개 + 일반 7개로 보충
             List<Card> candidates = mockCards(1L, 2L, 3L);
             given(cardQueryService.getRecommendCandidates(any())).willReturn(candidates);
             given(recommendScoringService.rank(any(), any(), any(), any(), any()))
@@ -201,7 +191,6 @@ class RecommendQueryServiceTest {
             given(cardQueryService.getRecommendCandidates(any())).willReturn(candidates);
             given(recommendScoringService.rank(any(), any(), any(), any(), any()))
                 .willAnswer(inv -> inv.getArgument(2));
-            // 일반 카드 ID 100, 101은 추천 카드 ID와 겹치지 않음
             given(cardQueryService.getLatestCards(any(), anyInt()))
                 .willReturn(memberCards(100L, 101L));
 
@@ -226,8 +215,7 @@ class RecommendQueryServiceTest {
         @BeforeEach
         void setUp() {
             given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of());
-            given(activeLogQueryService.getAllSwipedCardIds(USER_ID)).willReturn(Set.of());
-            given(activeLogQueryService.getSwipedCardIds(USER_ID, SwipeType.LIKE)).willReturn(List.of());
+            given(activeLogQueryService.getSwipedCards(USER_ID)).willReturn(SwipedCards.empty());
             given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
             given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
             given(recommendScoringService.rank(any(), any(), any(), any(), any()))
@@ -268,14 +256,13 @@ class RecommendQueryServiceTest {
         void setUp() {
             given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
             given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of());
-            given(activeLogQueryService.getAllSwipedCardIds(USER_ID)).willReturn(Set.of());
             given(cardQueryService.getLatestCards(any(), anyInt())).willReturn(List.of());
         }
 
         @Test
         @DisplayName("LIKE 이력이 없으면 빈 선호 맵으로 랭킹을 수행한다")
         void shouldRankWithEmptyPreferences_whenNoLikeHistory() {
-            given(activeLogQueryService.getSwipedCardIds(USER_ID, SwipeType.LIKE)).willReturn(List.of());
+            given(activeLogQueryService.getSwipedCards(USER_ID)).willReturn(SwipedCards.empty());
             given(cardCategoryQueryService.getCardCategoryMap(List.of())).willReturn(Map.of());
             given(recommendScoringService.calculateCategoryPreferenceRatios(List.of())).willReturn(Map.of());
             given(recommendScoringService.rank(any(), any(), any(), any(), any()))
@@ -290,10 +277,10 @@ class RecommendQueryServiceTest {
         @Test
         @DisplayName("LIKE한 카드에 카테고리 매핑이 없으면 빈 선호 맵으로 랭킹을 수행한다")
         void shouldRankWithEmptyPreferences_whenLikedCardsHaveNoCategories() {
-            given(activeLogQueryService.getSwipedCardIds(USER_ID, SwipeType.LIKE)).willReturn(List.of(10L, 20L));
-            given(cardCategoryQueryService.getCardCategoryMap(List.of(10L, 20L))).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(List.of())).willReturn(Map.of());
-            given(cardCategoryQueryService.getCardCategoryMap(List.of())).willReturn(Map.of());
+            given(activeLogQueryService.getSwipedCards(USER_ID))
+                .willReturn(new SwipedCards(Set.of(10L, 20L), Set.of()));
+            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
+            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
             given(recommendScoringService.rank(any(), any(), any(), any(), any()))
                 .willAnswer(inv -> inv.getArgument(2));
 
@@ -378,10 +365,9 @@ class RecommendQueryServiceTest {
         @Test
         @DisplayName("결과가 pageSize를 초과하지 않는다")
         void shouldNotExceedPageSize_whenStartCardPrepended() {
-            UUID otherUuid = UUID.randomUUID();
             GuestCardResult startCard = guestCard(START_UUID, "http://start.jpg");
             List<GuestCardResult> tenOthers = List.of(
-                    guestCard(otherUuid, "http://1.jpg"),
+                    guestCard(UUID.randomUUID(), "http://1.jpg"),
                     guestCard(UUID.randomUUID(), "http://2.jpg"),
                     guestCard(UUID.randomUUID(), "http://3.jpg"),
                     guestCard(UUID.randomUUID(), "http://4.jpg"),


### PR DESCRIPTION
## 개요

추천 API(`GET /w/v2/cards`) 1회 호출 시 `active_logs` 테이블을 2회 조회하던 중복 쿼리를
1회로 통합하고, 관련 자료구조를 Value Object로 캡슐화합니다.

## 변경 배경

기존에는 추천 후보군 필터링과 카테고리 선호도 계산을 위해 각각 별도로 active_logs를 조회했습니다.

```
쿼리1: active_logs WHERE swipe_type IN (LIKE, DISLIKE)  ← 스와이프한 카드 전체 제외용
쿼리2: active_logs WHERE swipe_type IN (LIKE)           ← 카테고리 선호도 계산용
```

두 조회를 단일 JPQL 쿼리로 통합하고, 결과를 서비스 레이어에서 분리하는 방식으로 개선합니다.

## 주요 변경사항

### 1. `SwipedCards` Value Object 도입
- `Map<SwipeType, Set<Long>>` 중첩 자료구조 → `SwipedCards` record로 캡슐화
- `allSwipedIds()` / `isAlreadySwiped()` / `likedIds()` 메서드로 의도를 명확히 표현
- compact constructor에서 `Set.copyOf()`로 불변성 보장

### 2. 중복 쿼리 통합
- `getAllSwipedCardIds()` + `getSwipedCardIds()` 2회 → `getSwipedCards()` 1회로 통합
- JPQL에서 `(cardId, swipeType)` 쌍 조회 후 `Collectors.groupingBy`로 서비스에서 분리

### 3. 미사용 메서드 제거
- `findByUserIdAndCardId` / `delete` — application 레이어 미사용 확인 후 인터페이스/Impl/JpaRepository 전체 제거

## 성능 측정 (실측)

| 항목 | Before | After |
|---|---|---|
| 총 쿼리 수 | 8 | 7 |
| active_logs 조회 | 2회 | 1회 |