### PR TITLE
[FIX] cardId 필드 누락 수정

### DIFF
--- a/src/main/java/com/dekk/app/card/application/dto/result/GuestCardResult.java
+++ b/src/main/java/com/dekk/app/card/application/dto/result/GuestCardResult.java
@@ -6,7 +6,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-public record GuestCardResult(Long cardId, UUID publicId, String cardImageUrl, Integer height, Integer weight, List<String> tags) {
+public record GuestCardResult(
+        Long cardId, UUID publicId, String cardImageUrl, Integer height, Integer weight, List<String> tags) {
     public static GuestCardResult from(Card card) {
         return new GuestCardResult(
                 card.getId(),

--- a/src/main/java/com/dekk/app/card/application/dto/result/GuestCardResult.java
+++ b/src/main/java/com/dekk/app/card/application/dto/result/GuestCardResult.java
@@ -6,9 +6,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
-public record GuestCardResult(UUID publicId, String cardImageUrl, Integer height, Integer weight, List<String> tags) {
+public record GuestCardResult(Long cardId, UUID publicId, String cardImageUrl, Integer height, Integer weight, List<String> tags) {
     public static GuestCardResult from(Card card) {
         return new GuestCardResult(
+                card.getId(),
                 card.getPublicId(),
                 card.getCardImage().getImageUrl(),
                 card.getHeight(),

--- a/src/main/java/com/dekk/app/card/presentation/response/GuestCardResponse.java
+++ b/src/main/java/com/dekk/app/card/presentation/response/GuestCardResponse.java
@@ -7,6 +7,9 @@ import java.util.UUID;
 
 @Schema(description = "비회원 카드 응답")
 public record GuestCardResponse(
+        @Schema(description = "카드 ID", example = "1")
+        Long cardId,
+
         @Schema(description = "카드 공개 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID publicId,
 
@@ -21,6 +24,6 @@ public record GuestCardResponse(
         List<String> tags) {
     public static GuestCardResponse from(GuestCardResult result) {
         return new GuestCardResponse(
-                result.publicId(), result.cardImageUrl(), result.height(), result.weight(), result.tags());
+                result.cardId(), result.publicId(), result.cardImageUrl(), result.height(), result.weight(), result.tags());
     }
 }

--- a/src/main/java/com/dekk/app/card/presentation/response/GuestCardResponse.java
+++ b/src/main/java/com/dekk/app/card/presentation/response/GuestCardResponse.java
@@ -7,8 +7,7 @@ import java.util.UUID;
 
 @Schema(description = "비회원 카드 응답")
 public record GuestCardResponse(
-        @Schema(description = "카드 ID", example = "1")
-        Long cardId,
+        @Schema(description = "카드 ID", example = "1") Long cardId,
 
         @Schema(description = "카드 공개 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID publicId,
@@ -24,6 +23,11 @@ public record GuestCardResponse(
         List<String> tags) {
     public static GuestCardResponse from(GuestCardResult result) {
         return new GuestCardResponse(
-                result.cardId(), result.publicId(), result.cardImageUrl(), result.height(), result.weight(), result.tags());
+                result.cardId(),
+                result.publicId(),
+                result.cardImageUrl(),
+                result.height(),
+                result.weight(),
+                result.tags());
     }
 }

--- a/src/main/java/com/dekk/app/card/presentation/response/MemberCardResponse.java
+++ b/src/main/java/com/dekk/app/card/presentation/response/MemberCardResponse.java
@@ -7,6 +7,9 @@ import java.util.UUID;
 
 @Schema(description = "회원 카드 응답")
 public record MemberCardResponse(
+        @Schema(description = "카드 ID", example = "1")
+        Long cardId,
+
         @Schema(description = "카드 공개 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID publicId,
 
@@ -43,6 +46,7 @@ public record MemberCardResponse(
 
     public static MemberCardResponse from(MemberCardResult result) {
         return new MemberCardResponse(
+                result.cardId(),
                 result.publicId(),
                 result.cardImageUrl(),
                 result.height(),

--- a/src/main/java/com/dekk/app/card/presentation/response/MemberCardResponse.java
+++ b/src/main/java/com/dekk/app/card/presentation/response/MemberCardResponse.java
@@ -7,8 +7,7 @@ import java.util.UUID;
 
 @Schema(description = "회원 카드 응답")
 public record MemberCardResponse(
-        @Schema(description = "카드 ID", example = "1")
-        Long cardId,
+        @Schema(description = "카드 ID", example = "1") Long cardId,
 
         @Schema(description = "카드 공개 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID publicId,

--- a/src/main/java/com/dekk/app/card/recommend/presentation/dto/response/RecommendCardResponse.java
+++ b/src/main/java/com/dekk/app/card/recommend/presentation/dto/response/RecommendCardResponse.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 
 @Schema(description = "추천 피드 카드 응답")
 public record RecommendCardResponse(
+        @Schema(description = "카드 ID", example = "1") Long cardId,
+
         @Schema(description = "카드 공개 ID", example = "550e8400-e29b-41d4-a716-446655440000")
         UUID publicId,
 
@@ -46,6 +48,7 @@ public record RecommendCardResponse(
     public static RecommendCardResponse from(RecommendCardResult result) {
         MemberCardResult card = result.card();
         return new RecommendCardResponse(
+                card.cardId(),
                 card.publicId(),
                 card.cardImageUrl(),
                 card.height(),

--- a/src/test/java/com/dekk/app/card/recommend/application/RecommendQueryServiceTest.java
+++ b/src/test/java/com/dekk/app/card/recommend/application/RecommendQueryServiceTest.java
@@ -391,7 +391,7 @@ class RecommendQueryServiceTest {
         }
 
         private GuestCardResult guestCard(UUID publicId, String imageUrl) {
-            return new GuestCardResult(null, publicId, imageUrl, null, null, List.of());
+            return new GuestCardResult(1L, publicId, imageUrl, null, null, List.of());
         }
     }
 

--- a/src/test/java/com/dekk/app/card/recommend/application/RecommendQueryServiceTest.java
+++ b/src/test/java/com/dekk/app/card/recommend/application/RecommendQueryServiceTest.java
@@ -391,7 +391,7 @@ class RecommendQueryServiceTest {
         }
 
         private GuestCardResult guestCard(UUID publicId, String imageUrl) {
-            return new GuestCardResult(publicId, imageUrl, null, null, List.of());
+            return new GuestCardResult(null, publicId, imageUrl, null, null, List.of());
         }
     }
 


### PR DESCRIPTION
## 문제 상황

메인 카드 피드에서 초기 5장(page=0) 이후 추가 카드가 로드되지 않고 `CardLoadingPlaceholder`만 표시됨.
네트워크 탭에서 `page=1~9`까지 요청은 발생하나 카드 추가 없음.

## 원인

`GuestCardResponse` / `MemberCardResponse`에 `cardId` 필드가 없었음.

FE `appendCardPage`의 중복 제거 로직:
```ts
seenCardIds.has(item.cardId)  // item.cardId === undefined
seenCardIds.add(item.cardId)  // Set에 undefined 추가
```

- **Page 0**: `seenCardIds.has(undefined)` → false → 5장 정상 추가, `seenCardIds.add(undefined)` → `seenCardIds = {undefined}`
- **Page 1+**: `seenCardIds.has(undefined)` → **true** → 전체 필터링 → `uniqueContent = []` → 3회 재시도 모두 실패 → 카드 미추가

## 수정 내역

| 파일 | 변경 내용 |
|------|-----------|
| `GuestCardResult.java` | `cardId(Long)` 필드 추가, `card.getId()` 매핑 |
| `GuestCardResponse.java` | `cardId` 필드 노출 |
| `MemberCardResponse.java` | `cardId` 필드 노출 (MemberCardResult에는 이미 존재) |
| `RecommendQueryServiceTest.java` | GuestCardResult 생성자 인자 순서 수정 |
