### PR TITLE
[REFACTOR] RecommendCandidateService 분리 및 설정값 외부화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,7 +42,6 @@ logs/
 
 # macOS metadata
 .DS_Store
-docs
 
 # === [DEKK Security & Environments] ===
 # 환경변수 파일

--- a/src/main/java/com/dekk/DekkApplication.java
+++ b/src/main/java/com/dekk/DekkApplication.java
@@ -2,10 +2,12 @@ package com.dekk;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class DekkApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendCandidateService.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendCandidateService.java
@@ -1,0 +1,90 @@
+package com.dekk.app.card.recommend.application;
+
+import com.dekk.app.activelog.domain.model.SwipedCards;
+import com.dekk.app.card.application.CardCategoryQueryService;
+import com.dekk.app.card.application.CardQueryService;
+import com.dekk.app.card.application.dto.query.RecommendCandidateQuery;
+import com.dekk.app.card.application.dto.result.MemberCardResult;
+import com.dekk.app.user.application.UserQueryService;
+import com.dekk.app.user.application.dto.result.UserInfoResult;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RecommendCandidateService {
+
+    private final CardQueryService cardQueryService;
+    private final UserQueryService userQueryService;
+    private final CardCategoryQueryService cardCategoryQueryService;
+    private final RecommendScoringService recommendScoringService;
+    private final RecommendProperties properties;
+
+    public List<MemberCardResult> rankCandidates(Long userId, SwipedCards swiped) {
+        UserInfoResult userInfo = userQueryService.getMyInfo(userId);
+        List<MemberCardResult> candidates = fetchCandidates(userInfo).stream()
+                .filter(card -> !swiped.isAlreadySwiped(card.cardId()))
+                .toList();
+
+        if (candidates.size() >= properties.largeCandidateThreshold()) {
+            log.warn("[Recommend] 대용량 후보군 스코어링 userId={} candidateCount={} - 인메모리 부하 위험", userId, candidates.size());
+        }
+
+        Map<Long, Double> preferences = buildCategoryPreferences(swiped.likedIds());
+
+        if (preferences.isEmpty()) {
+            log.info("[Recommend] cold-start userId={} (카테고리 선호 없음, 체형 기반으로만 추천)", userId);
+        }
+        log.debug(
+                "[Recommend] scoring userId={} candidateCount={} preferenceCategories={}",
+                userId,
+                candidates.size(),
+                preferences.size());
+
+        Map<Long, List<Long>> cardCategoryMap = cardCategoryQueryService.getCardCategoryMap(
+                candidates.stream().map(MemberCardResult::cardId).toList());
+
+        return recommendScoringService.rank(
+                userInfo.height(), userInfo.weight(), candidates, cardCategoryMap, preferences);
+    }
+
+    // recommendIds.size()만큼 오버 패치하여 필터 후에도 normalCount를 채울 수 있도록 보장
+    public List<MemberCardResult> fetchNormalCards(Set<Long> swipedIds, Set<Long> recommendIds, int normalCount) {
+        List<MemberCardResult> candidates =
+                cardQueryService.getLatestCards(swipedIds, normalCount + recommendIds.size());
+        return candidates.stream()
+                .filter(c -> !recommendIds.contains(c.cardId()))
+                .limit(normalCount)
+                .toList();
+    }
+
+    private List<MemberCardResult> fetchCandidates(UserInfoResult userInfo) {
+        return cardQueryService
+                .getRecommendCandidates(RecommendCandidateQuery.of(
+                        TargetGenderResolver.resolve(userInfo.gender()), userInfo.height(), userInfo.weight()))
+                .stream()
+                .map(MemberCardResult::from)
+                .toList();
+    }
+
+    private Map<Long, Double> buildCategoryPreferences(Set<Long> likedIds) {
+        return recommendScoringService.calculateCategoryPreferenceRatios(getLikedCategoryIds(likedIds));
+    }
+
+    private List<Long> getLikedCategoryIds(Set<Long> likedIds) {
+        if (likedIds.isEmpty()) {
+            return List.of();
+        }
+        return cardCategoryQueryService.getCardCategoryMap(new ArrayList<>(likedIds)).values().stream()
+                .flatMap(List::stream)
+                .toList();
+    }
+}

--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendCandidateService.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendCandidateService.java
@@ -34,6 +34,11 @@ public class RecommendCandidateService {
                 .filter(card -> !swiped.isAlreadySwiped(card.cardId()))
                 .toList();
 
+        if (candidates.isEmpty()) {
+            log.info("[Recommend] 후보 없음 userId={} (전부 스와이프 완료)", userId);
+            return List.of();
+        }
+
         if (candidates.size() >= properties.largeCandidateThreshold()) {
             log.warn("[Recommend] 대용량 후보군 스코어링 userId={} candidateCount={} - 인메모리 부하 위험", userId, candidates.size());
         }
@@ -56,7 +61,8 @@ public class RecommendCandidateService {
                 userInfo.height(), userInfo.weight(), candidates, cardCategoryMap, preferences);
     }
 
-    // recommendIds.size()만큼 오버 패치하여 필터 후에도 normalCount를 채울 수 있도록 보장
+    // recommendIds.size()만큼 오버 패치하여 필터 후에도 normalCount를 채울 수 있도록 보장.
+    // DB NOT IN 대신 in-memory 필터를 사용하여 오버패치 보장(DB 집합 연산 비용 없이 정확한 제외).
     public List<MemberCardResult> fetchNormalCards(Set<Long> swipedIds, Set<Long> recommendIds, int normalCount) {
         List<MemberCardResult> candidates =
                 cardQueryService.getLatestCards(swipedIds, normalCount + recommendIds.size());

--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendProperties.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendProperties.java
@@ -1,0 +1,14 @@
+package com.dekk.app.card.recommend.application;
+
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+@Validated
+@ConfigurationProperties(prefix = "recommend")
+public record RecommendProperties(
+        @DecimalMin("0.0") @DecimalMax("1.0") double ratio,
+        @Min(1) int deepScrollPageThreshold,
+        @Min(1) int largeCandidateThreshold) {}

--- a/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
+++ b/src/main/java/com/dekk/app/card/recommend/application/RecommendQueryService.java
@@ -2,17 +2,12 @@ package com.dekk.app.card.recommend.application;
 
 import com.dekk.app.activelog.application.ActiveLogQueryService;
 import com.dekk.app.activelog.domain.model.SwipedCards;
-import com.dekk.app.card.application.CardCategoryQueryService;
 import com.dekk.app.card.application.CardQueryService;
-import com.dekk.app.card.application.dto.query.RecommendCandidateQuery;
 import com.dekk.app.card.application.dto.result.GuestCardResult;
 import com.dekk.app.card.application.dto.result.MemberCardResult;
 import com.dekk.app.card.recommend.application.dto.RecommendCardResult;
-import com.dekk.app.user.application.UserQueryService;
-import com.dekk.app.user.application.dto.result.UserInfoResult;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -32,15 +27,10 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class RecommendQueryService {
 
-    private static final double RECOMMEND_RATIO = 0.7;
-    private static final int DEEP_SCROLL_PAGE_THRESHOLD = 10;
-    private static final int LARGE_CANDIDATE_THRESHOLD = 500;
-
     private final CardQueryService cardQueryService;
-    private final UserQueryService userQueryService;
     private final ActiveLogQueryService activeLogQueryService;
-    private final CardCategoryQueryService cardCategoryQueryService;
-    private final RecommendScoringService recommendScoringService;
+    private final RecommendCandidateService candidateService;
+    private final RecommendProperties properties;
 
     public Slice<RecommendCardResult> getRecommendCards(Long userId, Pageable pageable) {
         return getRecommendCards(userId, pageable, null);
@@ -72,9 +62,9 @@ public class RecommendQueryService {
 
     public Slice<RecommendCardResult> getRecommendCards(Long userId, Pageable pageable, UUID startCardId) {
         int totalNeeded = (int) (pageable.getOffset() + pageable.getPageSize());
-        int recommendCount = (int) Math.ceil(totalNeeded * RECOMMEND_RATIO);
+        int recommendCount = (int) Math.ceil(totalNeeded * properties.ratio());
 
-        if (pageable.getPageNumber() >= DEEP_SCROLL_PAGE_THRESHOLD) {
+        if (pageable.getPageNumber() >= properties.deepScrollPageThreshold()) {
             log.warn("[Recommend] 깊은 스크롤 감지 userId={} page={} - 컨텐츠 다양성 부족 가능성", userId, pageable.getPageNumber());
         }
 
@@ -87,7 +77,7 @@ public class RecommendQueryService {
                 totalNeeded,
                 recommendCount);
 
-        List<MemberCardResult> rankedCandidates = rankCandidates(userId, swiped);
+        List<MemberCardResult> rankedCandidates = candidateService.rankCandidates(userId, swiped);
 
         if (rankedCandidates.size() < recommendCount) {
             log.warn(
@@ -99,9 +89,10 @@ public class RecommendQueryService {
 
         List<MemberCardResult> recommendCards =
                 rankedCandidates.stream().limit(recommendCount).toList();
-        Set<Long> recommendIds = extractCardIds(recommendCards);
+        Set<Long> recommendIds =
+                recommendCards.stream().map(MemberCardResult::cardId).collect(Collectors.toSet());
         int normalCount = totalNeeded - recommendCards.size();
-        List<MemberCardResult> normalCards = fetchNormalCards(swipedIds, recommendIds, normalCount);
+        List<MemberCardResult> normalCards = candidateService.fetchNormalCards(swipedIds, recommendIds, normalCount);
 
         log.debug(
                 "[Recommend] userId={} served: recommend={} normal={}",
@@ -109,7 +100,7 @@ public class RecommendQueryService {
                 recommendCards.size(),
                 normalCards.size());
 
-        List<RecommendCardResult> allResults = mergeRecommendResults(recommendCards, normalCards);
+        List<RecommendCardResult> allResults = mergeResults(recommendCards, normalCards);
 
         if (startCardId != null && pageable.getPageNumber() == 0) {
             allResults = prependStartCard(startCardId, allResults);
@@ -130,22 +121,7 @@ public class RecommendQueryService {
         return merged;
     }
 
-    private Set<Long> extractCardIds(List<MemberCardResult> cards) {
-        return cards.stream().map(MemberCardResult::cardId).collect(Collectors.toSet());
-    }
-
-    // 추천 카드 IDs는 DB exclude 대신 in-memory 필터로 확실히 제거
-    // recommendIds.size()만큼 오버 패치하여 필터 후에도 normalCount를 채울 수 있도록 보장
-    private List<MemberCardResult> fetchNormalCards(Set<Long> swipedIds, Set<Long> recommendIds, int normalCount) {
-        List<MemberCardResult> candidates =
-                cardQueryService.getLatestCards(swipedIds, normalCount + recommendIds.size());
-        return candidates.stream()
-                .filter(c -> !recommendIds.contains(c.cardId()))
-                .limit(normalCount)
-                .toList();
-    }
-
-    private List<RecommendCardResult> mergeRecommendResults(
+    private List<RecommendCardResult> mergeResults(
             List<MemberCardResult> recommendCards, List<MemberCardResult> normalCards) {
         return Stream.concat(
                         recommendCards.stream().map(RecommendCardResult::recommended),
@@ -160,55 +136,5 @@ public class RecommendQueryService {
         List<RecommendCardResult> content = start >= allResults.size() ? List.of() : allResults.subList(start, end);
         boolean hasNext = allResults.size() >= totalNeeded;
         return new SliceImpl<>(content, pageable, hasNext);
-    }
-
-    private List<MemberCardResult> rankCandidates(Long userId, SwipedCards swiped) {
-        UserInfoResult userInfo = userQueryService.getMyInfo(userId);
-        List<MemberCardResult> candidates = fetchCandidates(userInfo).stream()
-                .filter(card -> !swiped.isAlreadySwiped(card.cardId()))
-                .toList();
-
-        if (candidates.size() >= LARGE_CANDIDATE_THRESHOLD) {
-            log.warn("[Recommend] 대용량 후보군 스코어링 userId={} candidateCount={} - 인메모리 부하 위험", userId, candidates.size());
-        }
-        Map<Long, Double> preferences = buildCategoryPreferences(swiped.likedIds());
-
-        if (preferences.isEmpty()) {
-            log.info("[Recommend] cold-start userId={} (카테고리 선호 없음, 체형 기반으로만 추천)", userId);
-        }
-        log.debug(
-                "[Recommend] scoring userId={} candidateCount={} preferenceCategories={}",
-                userId,
-                candidates.size(),
-                preferences.size());
-
-        Map<Long, List<Long>> cardCategoryMap = cardCategoryQueryService.getCardCategoryMap(
-                candidates.stream().map(MemberCardResult::cardId).toList());
-
-        return recommendScoringService.rank(
-                userInfo.height(), userInfo.weight(), candidates, cardCategoryMap, preferences);
-    }
-
-    private Map<Long, Double> buildCategoryPreferences(Set<Long> likedIds) {
-        List<Long> likedCategoryIds = getLikedCategoryIds(likedIds);
-        return recommendScoringService.calculateCategoryPreferenceRatios(likedCategoryIds);
-    }
-
-    private List<MemberCardResult> fetchCandidates(UserInfoResult userInfo) {
-        return cardQueryService
-                .getRecommendCandidates(RecommendCandidateQuery.of(
-                        TargetGenderResolver.resolve(userInfo.gender()), userInfo.height(), userInfo.weight()))
-                .stream()
-                .map(MemberCardResult::from)
-                .toList();
-    }
-
-    private List<Long> getLikedCategoryIds(Set<Long> likedIds) {
-        if (likedIds.isEmpty()) {
-            return List.of();
-        }
-        return cardCategoryQueryService.getCardCategoryMap(new ArrayList<>(likedIds)).values().stream()
-                .flatMap(List::stream)
-                .toList();
     }
 }

--- a/src/main/java/com/dekk/app/resource/infrastructure/storage/S3Config.java
+++ b/src/main/java/com/dekk/app/resource/infrastructure/storage/S3Config.java
@@ -1,6 +1,5 @@
 package com.dekk.app.resource.infrastructure.storage;
 
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import software.amazon.awssdk.regions.Region;
@@ -8,7 +7,6 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
-@EnableConfigurationProperties(StorageProperties.class)
 public class S3Config {
 
     @Bean

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,11 @@ springdoc:
   api-docs:
     path: /v3/api-docs
 
+recommend:
+  ratio: 0.7
+  deep-scroll-page-threshold: 10
+  large-candidate-threshold: 500
+
 jwt:
   access-token-validity-in-seconds: 3600
   refresh-token-validity-in-seconds: 1209600

--- a/src/test/java/com/dekk/app/card/recommend/application/RecommendCandidateServiceTest.java
+++ b/src/test/java/com/dekk/app/card/recommend/application/RecommendCandidateServiceTest.java
@@ -1,0 +1,242 @@
+package com.dekk.app.card.recommend.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.mock;
+
+import com.dekk.app.activelog.domain.model.SwipedCards;
+import com.dekk.app.card.application.CardCategoryQueryService;
+import com.dekk.app.card.application.CardQueryService;
+import com.dekk.app.card.application.dto.query.RecommendCandidateQuery;
+import com.dekk.app.card.application.dto.result.MemberCardResult;
+import com.dekk.app.card.domain.model.Card;
+import com.dekk.app.card.domain.model.CardImage;
+import com.dekk.app.card.domain.model.enums.TargetGender;
+import com.dekk.app.user.application.UserQueryService;
+import com.dekk.app.user.application.dto.result.UserInfoResult;
+import com.dekk.app.user.domain.model.enums.Gender;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RecommendCandidateServiceTest {
+
+    private static final Long USER_ID = 1L;
+
+    @Mock private CardQueryService cardQueryService;
+    @Mock private UserQueryService userQueryService;
+    @Mock private CardCategoryQueryService cardCategoryQueryService;
+    @Mock private RecommendScoringService recommendScoringService;
+
+    private RecommendCandidateService candidateService;
+
+    @BeforeEach
+    void setUp() {
+        candidateService = new RecommendCandidateService(
+                cardQueryService, userQueryService, cardCategoryQueryService,
+                recommendScoringService, new RecommendProperties(0.7, 10, 500));
+    }
+
+    @Nested
+    @DisplayName("스와이프 이력 제외")
+    class ExcludeSwipedCards {
+
+        @BeforeEach
+        void setUp() {
+            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
+            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
+            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
+            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
+                    .willAnswer(inv -> inv.getArgument(2));
+        }
+
+        @Test
+        @DisplayName("스와이프한 카드는 후보군에서 제외된다")
+        void shouldExcludeSwipedCards_whenSwipedIdsExist() {
+            Card c10 = mockCard(10L), c20 = mockCard(20L), c30 = mockCard(30L);
+            given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of(c10, c20, c30));
+
+            List<MemberCardResult> result = candidateService.rankCandidates(
+                    USER_ID, new SwipedCards(Set.of(10L, 20L), Set.of()));
+
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().cardId()).isEqualTo(30L);
+        }
+
+        @Test
+        @DisplayName("스와이프 이력이 없으면 후보 카드 전체가 반환된다")
+        void shouldIncludeAllCandidates_whenNoSwipeHistory() {
+            Card c1 = mockCard(1L), c2 = mockCard(2L);
+            given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of(c1, c2));
+
+            List<MemberCardResult> result = candidateService.rankCandidates(USER_ID, SwipedCards.empty());
+
+            assertThat(result).hasSize(2);
+        }
+
+        @Test
+        @DisplayName("모든 후보 카드를 스와이프했으면 빈 목록을 반환한다")
+        void shouldReturnEmpty_whenAllCandidatesSwiped() {
+            Card c1 = mockCard(1L), c2 = mockCard(2L);
+            given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of(c1, c2));
+
+            List<MemberCardResult> result = candidateService.rankCandidates(
+                    USER_ID, new SwipedCards(Set.of(1L, 2L), Set.of()));
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("유저 프로파일 기반 필터링")
+    class ProfileBasedFiltering {
+
+        @BeforeEach
+        void setUp() {
+            given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of());
+            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
+            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
+            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
+                    .willAnswer(inv -> inv.getArgument(2));
+        }
+
+        @Test
+        @DisplayName("성별 정보가 없으면 모든 TargetGender를 포함한 쿼리로 조회된다")
+        void shouldQueryAllGenders_whenGenderIsNull() {
+            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(null, 170, 65));
+            ArgumentCaptor<RecommendCandidateQuery> captor =
+                    ArgumentCaptor.forClass(RecommendCandidateQuery.class);
+
+            candidateService.rankCandidates(USER_ID, SwipedCards.empty());
+
+            then(cardQueryService).should().getRecommendCandidates(captor.capture());
+            assertThat(captor.getValue().genders())
+                    .containsExactlyInAnyOrderElementsOf(Arrays.asList(TargetGender.values()));
+        }
+
+        @Test
+        @DisplayName("MALE이면 MEN/OTHER만 포함한 쿼리로 조회된다")
+        void shouldQueryMaleGenders_whenGenderIsMale() {
+            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
+            ArgumentCaptor<RecommendCandidateQuery> captor =
+                    ArgumentCaptor.forClass(RecommendCandidateQuery.class);
+
+            candidateService.rankCandidates(USER_ID, SwipedCards.empty());
+
+            then(cardQueryService).should().getRecommendCandidates(captor.capture());
+            assertThat(captor.getValue().genders())
+                    .containsExactlyInAnyOrder(TargetGender.MEN, TargetGender.OTHER);
+        }
+
+        @Test
+        @DisplayName("체형 정보가 없으면 기본 범위(0~999)로 카드가 조회된다")
+        void shouldUseDefaultRange_whenBodyInfoIsNull() {
+            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, null, null));
+            ArgumentCaptor<RecommendCandidateQuery> captor =
+                    ArgumentCaptor.forClass(RecommendCandidateQuery.class);
+            Card c1 = mockCard(1L);
+            given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of(c1));
+
+            candidateService.rankCandidates(USER_ID, SwipedCards.empty());
+
+            then(cardQueryService).should().getRecommendCandidates(captor.capture());
+            RecommendCandidateQuery query = captor.getValue();
+            assertThat(query.minHeight()).isZero();
+            assertThat(query.maxHeight()).isEqualTo(999);
+            assertThat(query.minWeight()).isZero();
+            assertThat(query.maxWeight()).isEqualTo(999);
+        }
+    }
+
+    @Nested
+    @DisplayName("LIKE 카드 기반 카테고리 선호도 반영")
+    class CategoryPreference {
+
+        @BeforeEach
+        void setUp() {
+            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
+            given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of());
+            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
+                    .willAnswer(inv -> inv.getArgument(2));
+        }
+
+        @Test
+        @DisplayName("LIKE 이력이 없으면 빈 선호 맵으로 랭킹을 수행한다")
+        void shouldRankWithEmptyPreferences_whenNoLikeHistory() {
+            given(cardCategoryQueryService.getCardCategoryMap(List.of())).willReturn(Map.of());
+            given(recommendScoringService.calculateCategoryPreferenceRatios(List.of())).willReturn(Map.of());
+
+            List<MemberCardResult> result = candidateService.rankCandidates(USER_ID, SwipedCards.empty());
+
+            assertThat(result).isEmpty();
+        }
+
+        @Test
+        @DisplayName("LIKE한 카드에 카테고리 매핑이 없으면 빈 선호 맵으로 랭킹을 수행한다")
+        void shouldRankWithEmptyPreferences_whenLikedCardsHaveNoCategories() {
+            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
+            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
+
+            List<MemberCardResult> result = candidateService.rankCandidates(
+                    USER_ID, new SwipedCards(Set.of(10L, 20L), Set.of()));
+
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("일반 카드 fetch")
+    class FetchNormalCards {
+
+        @Test
+        @DisplayName("추천 카드 ID는 일반 카드 결과에서 제외된다")
+        void shouldExcludeRecommendIds_fromNormalCards() {
+            given(cardQueryService.getLatestCards(any(), anyInt()))
+                    .willReturn(List.of(
+                            memberCard(1L), memberCard(2L), memberCard(100L), memberCard(101L)));
+
+            List<MemberCardResult> result = candidateService.fetchNormalCards(
+                    Set.of(), Set.of(1L, 2L), 3);
+
+            assertThat(result).hasSize(2);
+            assertThat(result.stream().map(MemberCardResult::cardId).toList())
+                    .containsExactly(100L, 101L);
+        }
+    }
+
+    private UserInfoResult userInfo(Gender gender, Integer height, Integer weight) {
+        return new UserInfoResult(USER_ID, "test@test.com", "닉네임", height, weight, gender, "ACTIVE", "USER");
+    }
+
+    private Card mockCard(Long cardId) {
+        Card card = mock(Card.class);
+        CardImage cardImage = mock(CardImage.class);
+        given(card.getId()).willReturn(cardId);
+        given(card.getPublicId()).willReturn(UUID.randomUUID());
+        given(card.getCardImage()).willReturn(cardImage);
+        given(cardImage.getImageUrl()).willReturn("http://image.url/" + cardId);
+        given(card.getHeight()).willReturn(170);
+        given(card.getWeight()).willReturn(65);
+        given(card.getTags()).willReturn(null);
+        given(card.getCardProducts()).willReturn(List.of());
+        return card;
+    }
+
+    private MemberCardResult memberCard(Long id) {
+        return new MemberCardResult(id, null, null, null, null, List.of(), List.of());
+    }
+}

--- a/src/test/java/com/dekk/app/card/recommend/application/RecommendCandidateServiceTest.java
+++ b/src/test/java/com/dekk/app/card/recommend/application/RecommendCandidateServiceTest.java
@@ -58,10 +58,6 @@ class RecommendCandidateServiceTest {
         @BeforeEach
         void setUp() {
             given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
-            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                    .willAnswer(inv -> inv.getArgument(2));
         }
 
         @Test
@@ -69,6 +65,10 @@ class RecommendCandidateServiceTest {
         void shouldExcludeSwipedCards_whenSwipedIdsExist() {
             Card c10 = mockCard(10L), c20 = mockCard(20L), c30 = mockCard(30L);
             given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of(c10, c20, c30));
+            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
+            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
+            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
+                    .willAnswer(inv -> inv.getArgument(2));
 
             List<MemberCardResult> result = candidateService.rankCandidates(
                     USER_ID, new SwipedCards(Set.of(10L, 20L), Set.of()));
@@ -82,6 +82,10 @@ class RecommendCandidateServiceTest {
         void shouldIncludeAllCandidates_whenNoSwipeHistory() {
             Card c1 = mockCard(1L), c2 = mockCard(2L);
             given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of(c1, c2));
+            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
+            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
+            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
+                    .willAnswer(inv -> inv.getArgument(2));
 
             List<MemberCardResult> result = candidateService.rankCandidates(USER_ID, SwipedCards.empty());
 
@@ -108,10 +112,6 @@ class RecommendCandidateServiceTest {
         @BeforeEach
         void setUp() {
             given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of());
-            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                    .willAnswer(inv -> inv.getArgument(2));
         }
 
         @Test
@@ -150,6 +150,10 @@ class RecommendCandidateServiceTest {
                     ArgumentCaptor.forClass(RecommendCandidateQuery.class);
             Card c1 = mockCard(1L);
             given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of(c1));
+            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
+            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
+            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
+                    .willAnswer(inv -> inv.getArgument(2));
 
             candidateService.rankCandidates(USER_ID, SwipedCards.empty());
 
@@ -170,27 +174,19 @@ class RecommendCandidateServiceTest {
         void setUp() {
             given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
             given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of());
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                    .willAnswer(inv -> inv.getArgument(2));
         }
 
         @Test
-        @DisplayName("LIKE 이력이 없으면 빈 선호 맵으로 랭킹을 수행한다")
+        @DisplayName("LIKE 이력이 없으면 후보가 없을 때 빈 결과를 반환한다")
         void shouldRankWithEmptyPreferences_whenNoLikeHistory() {
-            given(cardCategoryQueryService.getCardCategoryMap(List.of())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(List.of())).willReturn(Map.of());
-
             List<MemberCardResult> result = candidateService.rankCandidates(USER_ID, SwipedCards.empty());
 
             assertThat(result).isEmpty();
         }
 
         @Test
-        @DisplayName("LIKE한 카드에 카테고리 매핑이 없으면 빈 선호 맵으로 랭킹을 수행한다")
+        @DisplayName("LIKE한 카드에 카테고리 매핑이 없으면 후보가 없을 때 빈 결과를 반환한다")
         void shouldRankWithEmptyPreferences_whenLikedCardsHaveNoCategories() {
-            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
-
             List<MemberCardResult> result = candidateService.rankCandidates(
                     USER_ID, new SwipedCards(Set.of(10L, 20L), Set.of()));
 

--- a/src/test/java/com/dekk/app/card/recommend/application/RecommendQueryServiceTest.java
+++ b/src/test/java/com/dekk/app/card/recommend/application/RecommendQueryServiceTest.java
@@ -3,36 +3,23 @@ package com.dekk.app.card.recommend.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anySet;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 
 import com.dekk.app.activelog.application.ActiveLogQueryService;
 import com.dekk.app.activelog.domain.model.SwipedCards;
-import com.dekk.app.card.application.CardCategoryQueryService;
 import com.dekk.app.card.application.CardQueryService;
 import com.dekk.app.card.application.dto.result.GuestCardResult;
 import com.dekk.app.card.application.dto.result.MemberCardResult;
-import com.dekk.app.card.domain.model.Card;
-import com.dekk.app.card.domain.model.CardImage;
-import com.dekk.app.card.recommend.application.RecommendQueryService;
-import com.dekk.app.card.recommend.application.RecommendScoringService;
 import com.dekk.app.card.recommend.application.dto.RecommendCardResult;
-import com.dekk.app.user.application.UserQueryService;
-import com.dekk.app.user.application.dto.result.UserInfoResult;
-import com.dekk.app.user.domain.model.enums.Gender;
-
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
-
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageRequest;
@@ -45,80 +32,16 @@ class RecommendQueryServiceTest {
     private static final int SIZE = 10;
 
     @Mock private CardQueryService cardQueryService;
-    @Mock private UserQueryService userQueryService;
     @Mock private ActiveLogQueryService activeLogQueryService;
-    @Mock private CardCategoryQueryService cardCategoryQueryService;
-    @Mock private RecommendScoringService recommendScoringService;
+    @Mock private RecommendCandidateService candidateService;
 
-    @InjectMocks
     private RecommendQueryService recommendQueryService;
 
-    @Nested
-    @DisplayName("스와이프 이력 제외")
-    class ExcludeSwipedCards {
-
-        @BeforeEach
-        void setUp() {
-            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
-            given(activeLogQueryService.getSwipedCards(USER_ID)).willReturn(SwipedCards.empty());
-            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                .willAnswer(inv -> inv.getArgument(2));
-            given(cardQueryService.getLatestCards(any(), anyInt())).willReturn(List.of());
-        }
-
-        @Test
-        @DisplayName("스와이프한 카드는 추천 결과에서 제외된다")
-        void shouldExcludeSwipedCards_whenSwipedIdsExist() {
-            Card card10 = mockCard(10L);
-            Card card20 = mockCard(20L);
-            Card card30 = mockCard(30L);
-
-            given(cardQueryService.getRecommendCandidates(any()))
-                .willReturn(List.of(card10, card20, card30));
-            given(activeLogQueryService.getSwipedCards(USER_ID))
-                .willReturn(new SwipedCards(Set.of(10L, 20L), Set.of()));
-
-            List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
-
-            List<RecommendCardResult> recommended = recommendedOnly(result);
-            assertThat(recommended).hasSize(1);
-            assertThat(recommended.getFirst().card().cardId()).isEqualTo(30L);
-        }
-
-        @Test
-        @DisplayName("스와이프 이력이 없으면 후보 카드 전체가 추천 대상이 된다")
-        void shouldIncludeAllCandidates_whenNoSwipeHistory() {
-            Card card1 = mockCard(1L);
-            Card card2 = mockCard(2L);
-
-            given(cardQueryService.getRecommendCandidates(any()))
-                .willReturn(List.of(card1, card2));
-
-            List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
-
-            assertThat(recommendedOnly(result)).hasSize(2);
-        }
-
-        @Test
-        @DisplayName("모든 후보 카드를 스와이프했으면 추천 카드는 없다")
-        void shouldHaveNoRecommended_whenAllCandidatesSwiped() {
-            Card card1 = mockCard(1L);
-            Card card2 = mockCard(2L);
-
-            given(cardQueryService.getRecommendCandidates(any()))
-                .willReturn(List.of(card1, card2));
-            given(activeLogQueryService.getSwipedCards(USER_ID))
-                .willReturn(new SwipedCards(Set.of(1L, 2L), Set.of()));
-
-            List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
-
-            assertThat(recommendedOnly(result)).isEmpty();
-        }
+    @BeforeEach
+    void setUp() {
+        recommendQueryService = new RecommendQueryService(
+                cardQueryService, activeLogQueryService, candidateService,
+                new RecommendProperties(0.7, 10, 500));
     }
 
     @Nested
@@ -127,24 +50,19 @@ class RecommendQueryServiceTest {
 
         @BeforeEach
         void setUp() {
-            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
             given(activeLogQueryService.getSwipedCards(USER_ID)).willReturn(SwipedCards.empty());
-            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
         }
 
         @Test
         @DisplayName("size=10이면 추천 7개(70%), 일반 3개(30%)로 구성된다")
         void shouldReturn7Recommended3Normal_whenSize10() {
-            List<Card> candidates = mockCards(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L);
-            given(cardQueryService.getRecommendCandidates(any())).willReturn(candidates);
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                .willAnswer(inv -> inv.getArgument(2));
-            given(cardQueryService.getLatestCards(any(), anyInt()))
-                .willReturn(memberCards(100L, 101L, 102L));
+            given(candidateService.rankCandidates(any(), any()))
+                    .willReturn(memberCards(10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L));
+            given(candidateService.fetchNormalCards(anySet(), anySet(), anyInt()))
+                    .willReturn(memberCards(100L, 101L, 102L));
 
             List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
 
             assertThat(recommendedOnly(result)).hasSize(7);
             assertThat(normalOnly(result)).hasSize(3);
@@ -153,15 +71,13 @@ class RecommendQueryServiceTest {
         @Test
         @DisplayName("추천 후보가 부족하면 일반 카드로 나머지를 채운다")
         void shouldFillWithNormalCards_whenRecommendInsufficient() {
-            List<Card> candidates = mockCards(1L, 2L, 3L);
-            given(cardQueryService.getRecommendCandidates(any())).willReturn(candidates);
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                .willAnswer(inv -> inv.getArgument(2));
-            given(cardQueryService.getLatestCards(any(), anyInt()))
-                .willReturn(memberCards(100L, 101L, 102L, 103L, 104L, 105L, 106L));
+            given(candidateService.rankCandidates(any(), any()))
+                    .willReturn(memberCards(1L, 2L, 3L));
+            given(candidateService.fetchNormalCards(anySet(), anySet(), anyInt()))
+                    .willReturn(memberCards(100L, 101L, 102L, 103L, 104L, 105L, 106L));
 
             List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
 
             assertThat(recommendedOnly(result)).hasSize(3);
             assertThat(normalOnly(result)).hasSize(7);
@@ -170,15 +86,12 @@ class RecommendQueryServiceTest {
         @Test
         @DisplayName("recommended=true 카드와 recommended=false 카드가 올바르게 구분된다")
         void shouldTagRecommendedFlagCorrectly() {
-            List<Card> candidates = mockCards(1L);
-            given(cardQueryService.getRecommendCandidates(any())).willReturn(candidates);
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                .willAnswer(inv -> inv.getArgument(2));
-            given(cardQueryService.getLatestCards(any(), anyInt()))
-                .willReturn(memberCards(100L));
+            given(candidateService.rankCandidates(any(), any())).willReturn(memberCards(1L));
+            given(candidateService.fetchNormalCards(anySet(), anySet(), anyInt()))
+                    .willReturn(memberCards(100L));
 
             List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
 
             assertThat(result).anyMatch(RecommendCardResult::recommended);
             assertThat(result).anyMatch(r -> !r.recommended());
@@ -187,107 +100,111 @@ class RecommendQueryServiceTest {
         @Test
         @DisplayName("일반 카드에는 추천 카드 ID가 포함되지 않는다")
         void shouldExcludeRecommendedIdsFromNormalCards() {
-            List<Card> candidates = mockCards(1L, 2L);
-            given(cardQueryService.getRecommendCandidates(any())).willReturn(candidates);
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                .willAnswer(inv -> inv.getArgument(2));
-            given(cardQueryService.getLatestCards(any(), anyInt()))
-                .willReturn(memberCards(100L, 101L));
+            given(candidateService.rankCandidates(any(), any())).willReturn(memberCards(1L, 2L));
+            given(candidateService.fetchNormalCards(anySet(), anySet(), anyInt()))
+                    .willReturn(memberCards(100L, 101L));
 
             List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
+                    recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, 10)).getContent();
 
-            Set<Long> recommendedIds = recommendedOnly(result).stream()
-                .map(r -> r.card().cardId())
-                .collect(java.util.stream.Collectors.toSet());
-            Set<Long> normalIds = normalOnly(result).stream()
-                .map(r -> r.card().cardId())
-                .collect(java.util.stream.Collectors.toSet());
+            java.util.Set<Long> recommendedIds = recommendedOnly(result).stream()
+                    .map(r -> r.card().cardId())
+                    .collect(java.util.stream.Collectors.toSet());
+            java.util.Set<Long> normalIds = normalOnly(result).stream()
+                    .map(r -> r.card().cardId())
+                    .collect(java.util.stream.Collectors.toSet());
 
             assertThat(recommendedIds).doesNotContainAnyElementsOf(normalIds);
         }
     }
 
     @Nested
-    @DisplayName("유저 프로파일 기반 필터링")
-    class ProfileBasedFiltering {
+    @DisplayName("회원 SEO startCardId 처리")
+    class MemberStartCard {
+
+        private final UUID START_UUID = UUID.randomUUID();
+        private final PageRequest PAGE = PageRequest.of(0, 10);
 
         @BeforeEach
         void setUp() {
-            given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of());
             given(activeLogQueryService.getSwipedCards(USER_ID)).willReturn(SwipedCards.empty());
-            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                .willAnswer(inv -> inv.getArgument(2));
-            given(cardQueryService.getLatestCards(any(), anyInt())).willReturn(List.of());
+            given(candidateService.rankCandidates(any(), any())).willReturn(List.of(
+                    memberCard(1L, UUID.randomUUID()),
+                    memberCard(2L, UUID.randomUUID()),
+                    memberCard(3L, UUID.randomUUID())));
+            given(candidateService.fetchNormalCards(anySet(), anySet(), anyInt())).willReturn(List.of(
+                    memberCard(100L, UUID.randomUUID()),
+                    memberCard(101L, UUID.randomUUID())));
         }
 
         @Test
-        @DisplayName("성별 정보가 없으면 전체 성별 대상으로 카드가 조회된다")
-        void shouldQueryAllGenders_whenGenderIsNull() {
-            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(null, 170, 65));
+        @DisplayName("startCardId가 존재하면 해당 카드가 첫 번째로 온다")
+        void shouldPrependStartCard_whenStartCardExists() {
+            MemberCardResult startCard = memberCard(99L, START_UUID);
+            given(cardQueryService.findByPublicId(START_UUID)).willReturn(Optional.of(startCard));
 
             List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
+                    recommendQueryService.getRecommendCards(USER_ID, PAGE, START_UUID).getContent();
 
-            assertThat(result).isEmpty();
+            assertThat(result.getFirst().card().publicId()).isEqualTo(START_UUID);
         }
 
         @Test
-        @DisplayName("체형 정보가 없으면 기본 범위(전체)로 카드가 조회된다")
-        void shouldUseDefaultRange_whenBodyInfoIsNull() {
-            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, null, null));
-            List<Card> candidates = mockCards(1L);
-            given(cardQueryService.getRecommendCandidates(any())).willReturn(candidates);
+        @DisplayName("startCardId가 이미 추천 목록에 있으면 중복 없이 첫 번째로 온다")
+        void shouldNotDuplicate_whenStartCardAlreadyInResults() {
+            MemberCardResult startCard = memberCard(1L, START_UUID);
+            given(candidateService.rankCandidates(any(), any()))
+                    .willReturn(List.of(startCard, memberCard(2L, UUID.randomUUID())));
+            given(candidateService.fetchNormalCards(anySet(), anySet(), anyInt()))
+                    .willReturn(List.of(memberCard(100L, UUID.randomUUID())));
+            given(cardQueryService.findByPublicId(START_UUID)).willReturn(Optional.of(startCard));
 
             List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
+                    recommendQueryService.getRecommendCards(USER_ID, PAGE, START_UUID).getContent();
 
-            assertThat(recommendedOnly(result)).hasSize(1);
-        }
-    }
-
-    @Nested
-    @DisplayName("LIKE 카드 기반 카테고리 선호도 반영")
-    class CategoryPreference {
-
-        @BeforeEach
-        void setUp() {
-            given(userQueryService.getMyInfo(USER_ID)).willReturn(userInfo(Gender.MALE, 175, 70));
-            given(cardQueryService.getRecommendCandidates(any())).willReturn(List.of());
-            given(cardQueryService.getLatestCards(any(), anyInt())).willReturn(List.of());
+            long count = result.stream()
+                    .filter(r -> START_UUID.equals(r.card().publicId()))
+                    .count();
+            assertThat(count).isEqualTo(1);
+            assertThat(result.getFirst().card().publicId()).isEqualTo(START_UUID);
         }
 
         @Test
-        @DisplayName("LIKE 이력이 없으면 빈 선호 맵으로 랭킹을 수행한다")
-        void shouldRankWithEmptyPreferences_whenNoLikeHistory() {
-            given(activeLogQueryService.getSwipedCards(USER_ID)).willReturn(SwipedCards.empty());
-            given(cardCategoryQueryService.getCardCategoryMap(List.of())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(List.of())).willReturn(Map.of());
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                .willAnswer(inv -> inv.getArgument(2));
+        @DisplayName("startCardId에 해당하는 카드가 없으면 결과 목록 그대로 반환한다")
+        void shouldReturnOriginalList_whenStartCardNotFound() {
+            given(cardQueryService.findByPublicId(START_UUID)).willReturn(Optional.empty());
 
             List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
+                    recommendQueryService.getRecommendCards(USER_ID, PAGE, START_UUID).getContent();
 
-            assertThat(result).isEmpty();
+            assertThat(result.getFirst().card().publicId()).isNotEqualTo(START_UUID);
         }
 
         @Test
-        @DisplayName("LIKE한 카드에 카테고리 매핑이 없으면 빈 선호 맵으로 랭킹을 수행한다")
-        void shouldRankWithEmptyPreferences_whenLikedCardsHaveNoCategories() {
-            given(activeLogQueryService.getSwipedCards(USER_ID))
-                .willReturn(new SwipedCards(Set.of(10L, 20L), Set.of()));
-            given(cardCategoryQueryService.getCardCategoryMap(any())).willReturn(Map.of());
-            given(recommendScoringService.calculateCategoryPreferenceRatios(any())).willReturn(Map.of());
-            given(recommendScoringService.rank(any(), any(), any(), any(), any()))
-                .willAnswer(inv -> inv.getArgument(2));
+        @DisplayName("page > 0이면 startCardId가 있어도 prepend하지 않는다")
+        void shouldNotPrepend_whenPageIsNotFirst() {
+            PageRequest page1 = PageRequest.of(1, 10);
+            given(candidateService.rankCandidates(any(), any())).willReturn(List.of(
+                    memberCard(1L, UUID.randomUUID()), memberCard(2L, UUID.randomUUID()),
+                    memberCard(3L, UUID.randomUUID()), memberCard(4L, UUID.randomUUID()),
+                    memberCard(5L, UUID.randomUUID()), memberCard(6L, UUID.randomUUID()),
+                    memberCard(7L, UUID.randomUUID()), memberCard(8L, UUID.randomUUID()),
+                    memberCard(9L, UUID.randomUUID()), memberCard(10L, UUID.randomUUID()),
+                    memberCard(11L, UUID.randomUUID()), memberCard(12L, UUID.randomUUID()),
+                    memberCard(13L, UUID.randomUUID()), memberCard(14L, UUID.randomUUID()),
+                    memberCard(15L, UUID.randomUUID()), memberCard(16L, UUID.randomUUID()),
+                    memberCard(17L, UUID.randomUUID()), memberCard(18L, UUID.randomUUID()),
+                    memberCard(19L, UUID.randomUUID()), memberCard(20L, UUID.randomUUID())));
+            given(candidateService.fetchNormalCards(anySet(), anySet(), anyInt())).willReturn(List.of(
+                    memberCard(100L, UUID.randomUUID()), memberCard(101L, UUID.randomUUID()),
+                    memberCard(102L, UUID.randomUUID()), memberCard(103L, UUID.randomUUID()),
+                    memberCard(104L, UUID.randomUUID()), memberCard(105L, UUID.randomUUID()),
+                    memberCard(106L, UUID.randomUUID()), memberCard(107L, UUID.randomUUID())));
 
             List<RecommendCardResult> result =
-                recommendQueryService.getRecommendCards(USER_ID, PageRequest.of(0, SIZE)).getContent();
+                    recommendQueryService.getRecommendCards(USER_ID, page1, START_UUID).getContent();
 
-            assertThat(result).isEmpty();
+            assertThat(result).noneMatch(r -> START_UUID.equals(r.card().publicId()));
         }
     }
 
@@ -376,8 +293,7 @@ class RecommendQueryServiceTest {
                     guestCard(UUID.randomUUID(), "http://7.jpg"),
                     guestCard(UUID.randomUUID(), "http://8.jpg"),
                     guestCard(UUID.randomUUID(), "http://9.jpg"),
-                    guestCard(UUID.randomUUID(), "http://10.jpg")
-            );
+                    guestCard(UUID.randomUUID(), "http://10.jpg"));
 
             given(cardQueryService.getCardsForGuestRandom(PAGE))
                     .willReturn(new SliceImpl<>(tenOthers, PAGE, false));
@@ -403,31 +319,13 @@ class RecommendQueryServiceTest {
         return result.stream().filter(r -> !r.recommended()).toList();
     }
 
-    private UserInfoResult userInfo(Gender gender, Integer height, Integer weight) {
-        return new UserInfoResult(USER_ID, "test@test.com", "닉네임", height, weight, gender, "ACTIVE", "USER");
-    }
-
-    private Card mockCard(Long cardId) {
-        Card card = mock(Card.class);
-        CardImage cardImage = mock(CardImage.class);
-        given(card.getId()).willReturn(cardId);
-        given(card.getPublicId()).willReturn(UUID.randomUUID());
-        given(card.getCardImage()).willReturn(cardImage);
-        given(cardImage.getImageUrl()).willReturn("http://image.url/" + cardId);
-        given(card.getHeight()).willReturn(170);
-        given(card.getWeight()).willReturn(65);
-        given(card.getTags()).willReturn(null);
-        given(card.getCardProducts()).willReturn(List.of());
-        return card;
-    }
-
-    private List<Card> mockCards(Long... ids) {
-        return java.util.Arrays.stream(ids).map(this::mockCard).toList();
-    }
-
     private List<MemberCardResult> memberCards(Long... ids) {
         return java.util.Arrays.stream(ids)
-            .map(id -> new MemberCardResult(id, null, null, null, null, List.of(), List.of()))
-            .toList();
+                .map(id -> new MemberCardResult(id, null, null, null, null, List.of(), List.of()))
+                .toList();
+    }
+
+    private MemberCardResult memberCard(Long id, UUID publicId) {
+        return new MemberCardResult(id, publicId, null, null, null, List.of(), List.of());
     }
 }


### PR DESCRIPTION
## 배경

추천 카드 조회 서비스(`RecommendQueryService`)에 후보군 조회/랭킹/일반 카드 fetch까지 모든 책임이 집중되어 있었고, 추천 비율/임계값 등 설정값이 소스 코드에 하드코딩되어 있었습니다.

## 변경 사항

### RecommendCandidateService 분리 (SRP)
- 후보군 조회, 스와이프 제외, 카테고리 선호도 반영, 랭킹, 일반 카드 fetch 로직을 `RecommendQueryService`에서 `RecommendCandidateService`로 이관
- `RecommendQueryService`는 페이지 구성(혼합 비율 적용, startCard prepend, Slice 변환)만 담당

### RecommendProperties (@ConfigurationProperties)
- `recommend.ratio`, `recommend.deep-scroll-page-threshold`, `recommend.large-candidate-threshold`를 `application.yml`로 외부화
- `@Validated` + JSR-303 제약(`@DecimalMin/Max`, `@Min`)으로 기동 시 설정값 자동 검증

### 테스트
- `RecommendCandidateServiceTest`: ArgumentCaptor로 쿼리 파라미터(성별/체형 범위) 검증
- `RecommendQueryServiceTest`: 추천/일반 혼합 비율, MemberStartCard/GuestStartCard SEO 처리 검증

## 테스트

- `./gradlew test --tests "com.dekk.app.card.recommend.application.*"` 전체 통과
- `./gradlew spotlessCheck` 통과